### PR TITLE
feat: add resource type selection for VM and VMSS in policy templates…

### DIFF
--- a/policy/README.md
+++ b/policy/README.md
@@ -44,6 +44,7 @@ The Azure Policy templates are available as part of the official CrowdStrike Azu
 
 ### Configuration Options
 - **Falcon Cloud**: Auto-discover, US-1, US-2, EU-1, US-GOV-1
+- **Resource Type Selection**: Deploy policies for VMs only, VMSS only, or both
 - **Member CID**: For MSSP scenarios
 - **Sensor Update Policy**: Configure to match your organization's desired sensor update policy instead of using the pre-defined default
 - **Tags**: Sensor grouping and organization
@@ -52,14 +53,14 @@ The Azure Policy templates are available as part of the official CrowdStrike Azu
 
 ## Policy Structure
 
-Each template creates **4 policy definitions** for comprehensive coverage:
+Each template can create up to **4 policy definitions** for comprehensive coverage:
 
 1. **Linux VM Policy** - Deploys Falcon sensor on individual Linux virtual machines
 2. **Linux VMSS Policy** - Deploys Falcon sensor on Linux Virtual Machine Scale Sets
 3. **Windows VM Policy** - Deploys Falcon sensor on individual Windows virtual machines
 4. **Windows VMSS Policy** - Deploys Falcon sensor on Windows Virtual Machine Scale Sets
 
-All policies support the same configuration parameters and authentication methods, ensuring consistent sensor deployment across your entire Azure compute infrastructure.
+Use the `resourceTypes` parameter to deploy only VM policies, only VMSS policies, or both. All policies support the same configuration parameters and authentication methods, ensuring consistent sensor deployment across your selected Azure compute infrastructure.
 
 ## Deployment Options
 
@@ -95,6 +96,24 @@ az deployment sub create \
     operatingSystem="windows" \
     clientId="your-client-id" \
     clientSecret="your-client-secret"
+
+# Deploy VM policies only, skipping VMSS
+az deployment sub create \
+  --location "East US" \
+  --template-file falcon-subscription.bicep \
+  --parameters \
+    resourceTypes="vm" \
+    clientId="your-client-id" \
+    clientSecret="your-client-secret"
+
+# Deploy VMSS policies only
+az deployment sub create \
+  --location "East US" \
+  --template-file falcon-subscription.bicep \
+  --parameters \
+    resourceTypes="vmss" \
+    clientId="your-client-id" \
+    clientSecret="your-client-secret"
 ```
 
 #### PowerShell
@@ -120,6 +139,22 @@ New-AzSubscriptionDeployment `
   -Location "East US" `
   -TemplateFile "falcon-subscription.bicep" `
   -operatingSystem "windows" `
+  -clientId "your-client-id" `
+  -clientSecret "your-client-secret"
+
+# Deploy VM policies only, skipping VMSS
+New-AzSubscriptionDeployment `
+  -Location "East US" `
+  -TemplateFile "falcon-subscription.bicep" `
+  -resourceTypes "vm" `
+  -clientId "your-client-id" `
+  -clientSecret "your-client-secret"
+
+# Deploy VMSS policies only
+New-AzSubscriptionDeployment `
+  -Location "East US" `
+  -TemplateFile "falcon-subscription.bicep" `
+  -resourceTypes "vmss" `
   -clientId "your-client-id" `
   -clientSecret "your-client-secret"
 ```
@@ -172,6 +207,16 @@ az deployment mg create \
     operatingSystem="windows" \
     clientId="your-client-id" \
     clientSecret="your-client-secret"
+
+# Deploy VM policies only at management group level, skipping VMSS
+az deployment mg create \
+  --management-group-id "my-management-group" \
+  --location "East US" \
+  --template-file falcon-managementgroup.bicep \
+  --parameters \
+    resourceTypes="vm" \
+    clientId="your-client-id" \
+    clientSecret="your-client-secret"
 ```
 
 #### PowerShell
@@ -200,6 +245,15 @@ New-AzManagementGroupDeployment `
   -Location "East US" `
   -TemplateFile "falcon-managementgroup.bicep" `
   -operatingSystem "windows" `
+  -clientId "your-client-id" `
+  -clientSecret "your-client-secret"
+
+# Deploy VM policies only at management group level, skipping VMSS
+New-AzManagementGroupDeployment `
+  -ManagementGroupId "my-management-group" `
+  -Location "East US" `
+  -TemplateFile "falcon-managementgroup.bicep" `
+  -resourceTypes "vm" `
   -clientId "your-client-id" `
   -clientSecret "your-client-secret"
 ```
@@ -249,6 +303,8 @@ See https://github.com/CrowdStrike/azure-vm-extension?tab=readme-ov-file#falcon-
 | `memberCid` | string | Member CID for MSSP | '' |
 | `sensorUpdatePolicy` | string | Sensor update policy name. Configure this to match your organization's desired sensor update policy instead of using the pre-defined default. | 'platform_default' |
 | `tags` | string | Comma-separated sensor tags | '' |
+| `operatingSystem` | string | Operating systems to deploy policies for: `linux`, `windows`, or `both` | 'both' |
+| `resourceTypes` | string | Azure compute resource types to deploy policies for: `vm`, `vmss`, or `both` | 'both' |
 | `policyEffect` | string | Policy effect | 'DeployIfNotExists' |
 | `createRoleAssignments` | bool | Create role assignments for managed identities | true |
 | `proxySettings` | object | Network proxy configuration settings | `{proxyHost: '', proxyPort: ''}` |
@@ -308,7 +364,7 @@ The templates create managed identities that need **Virtual Machine Contributor*
 
 ### Manual Role Assignment
 
-When `createRoleAssignments=false`, you must manually assign the VM Contributor role to all 4 policy managed identities:
+When `createRoleAssignments=false`, you must manually assign the VM Contributor role to the policy managed identities created by your selected `operatingSystem` and `resourceTypes` values:
 
 #### Azure CLI
 ```bash

--- a/policy/falcon-managementgroup.bicep
+++ b/policy/falcon-managementgroup.bicep
@@ -8,6 +8,14 @@ targetScope = 'managementGroup'
 ])
 param operatingSystem string = 'both'
 
+@description('Azure compute resource types to deploy policies for')
+@allowed([
+  'vm'
+  'vmss'
+  'both'
+])
+param resourceTypes string = 'both'
+
 @description('Policy definition name prefix')
 param policyDefinitionNamePrefix string = 'CS-Falcon-Policy'
 
@@ -56,6 +64,11 @@ param vdi bool = false
 
 // Variables
 var operatingSystemLower = toLower(operatingSystem)
+var resourceTypesLower = toLower(resourceTypes)
+var deployLinuxPolicies = operatingSystemLower == 'linux' || operatingSystemLower == 'both'
+var deployWindowsPolicies = operatingSystemLower == 'windows' || operatingSystemLower == 'both'
+var deployVmPolicies = resourceTypesLower == 'vm' || resourceTypesLower == 'both'
+var deployVmssPolicies = resourceTypesLower == 'vmss' || resourceTypesLower == 'both'
 var vmRoleDefinitionId = '9980e02c-c2be-4d73-94e8-173b1dc7cf3c' // Virtual Machine Contributor
 var linuxPolicyDefinitionName = '${policyDefinitionNamePrefix}-Linux'
 var windowsPolicyDefinitionName = '${policyDefinitionNamePrefix}-Windows'
@@ -309,7 +322,7 @@ var commonWindowsAssignmentParameters = union(commonLinuxAssignmentParameters, {
 })
 
 // Create Linux VM policy definition
-resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployLinuxPolicies && deployVmPolicies) {
   name: '${linuxPolicyDefinitionName}-VM'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMs'
@@ -403,7 +416,7 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
 }
 
 // Create Linux VMSS policy definition
-resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployLinuxPolicies && deployVmssPolicies) {
   name: '${linuxPolicyDefinitionName}-VMSS'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMSS'
@@ -497,7 +510,7 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
 }
 
 // Create Linux VM policy assignment at management group level
-resource linuxVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployLinuxPolicies && deployVmPolicies) {
   name: 'CS-Falcon-Linux-VM-MG'
   location: deployment().location
   identity: {
@@ -512,7 +525,7 @@ resource linuxVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020
 }
 
 // Create Linux VMSS policy assignment at management group level
-resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployLinuxPolicies && deployVmssPolicies) {
   name: 'CS-Falcon-Linux-VMSS-MG'
   location: deployment().location
   identity: {
@@ -527,7 +540,7 @@ resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@20
 }
 
 // Create Windows VM policy definition
-resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployWindowsPolicies && deployVmPolicies) {
   name: '${windowsPolicyDefinitionName}-VM'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMs'
@@ -626,7 +639,7 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
 }
 
 // Create Windows VMSS policy definition
-resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployWindowsPolicies && deployVmssPolicies) {
   name: '${windowsPolicyDefinitionName}-VMSS'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMSS'
@@ -725,7 +738,7 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
 }
 
 // Create Windows VM policy assignment at management group level
-resource windowsVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployWindowsPolicies && deployVmPolicies) {
   name: 'CS-Falcon-Windows-VM-MG'
   location: deployment().location
   identity: {
@@ -740,7 +753,7 @@ resource windowsVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@20
 }
 
 // Create Windows VMSS policy assignment at management group level
-resource windowsVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployWindowsPolicies && deployVmssPolicies) {
   name: 'CS-Falcon-Win-VMSS-MG'
   location: deployment().location
   identity: {
@@ -755,7 +768,7 @@ resource windowsVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@
 }
 
 // Create role assignments for the policies' managed identities (at management group scope)
-resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployLinuxPolicies && deployVmPolicies) {
   name: guid(linuxVmPolicyAssignment.id, vmRoleDefinitionId, managementGroup().id, 'LinuxVM')
   properties: {
     principalId: linuxVmPolicyAssignment!.identity.principalId
@@ -764,7 +777,7 @@ resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignmen
   }
 }
 
-resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployLinuxPolicies && deployVmssPolicies) {
   name: guid(linuxVmssPolicyAssignment.id, vmRoleDefinitionId, managementGroup().id, 'LinuxVMSS')
   properties: {
     principalId: linuxVmssPolicyAssignment!.identity.principalId
@@ -773,7 +786,7 @@ resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignm
   }
 }
 
-resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployWindowsPolicies && deployVmPolicies) {
   name: guid(windowsVmPolicyAssignment.id, vmRoleDefinitionId, managementGroup().id, 'WindowsVM')
   properties: {
     principalId: windowsVmPolicyAssignment!.identity.principalId
@@ -782,7 +795,7 @@ resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignm
   }
 }
 
-resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployWindowsPolicies && deployVmssPolicies) {
   name: guid(windowsVmssPolicyAssignment.id, vmRoleDefinitionId, managementGroup().id, 'WindowsVMSS')
   properties: {
     principalId: windowsVmssPolicyAssignment!.identity.principalId
@@ -792,17 +805,17 @@ resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssig
 }
 
 // Outputs
-output linuxVmPolicyDefinitionId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyDefinition.id : ''
-output linuxVmssPolicyDefinitionId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyDefinition.id : ''
-output windowsVmPolicyDefinitionId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyDefinition.id : ''
-output windowsVmssPolicyDefinitionId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmssPolicyDefinition.id : ''
-output linuxVmPolicyAssignmentId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyAssignment.id : ''
-output linuxVmssPolicyAssignmentId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyAssignment.id : ''
-output windowsVmPolicyAssignmentId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyAssignment.id : ''
-output windowsVmssPolicyAssignmentId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmssPolicyAssignment.id : ''
-output linuxVmPolicyPrincipalId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyAssignment!.identity.principalId : ''
-output linuxVmssPolicyPrincipalId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyAssignment!.identity.principalId : ''
-output windowsVmPolicyPrincipalId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyAssignment!.identity.principalId : ''
-output windowsVmssPolicyPrincipalId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmssPolicyAssignment!.identity.principalId : ''
+output linuxVmPolicyDefinitionId string = (deployLinuxPolicies && deployVmPolicies) ? linuxVmPolicyDefinition.id : ''
+output linuxVmssPolicyDefinitionId string = (deployLinuxPolicies && deployVmssPolicies) ? linuxVmssPolicyDefinition.id : ''
+output windowsVmPolicyDefinitionId string = (deployWindowsPolicies && deployVmPolicies) ? windowsVmPolicyDefinition.id : ''
+output windowsVmssPolicyDefinitionId string = (deployWindowsPolicies && deployVmssPolicies) ? windowsVmssPolicyDefinition.id : ''
+output linuxVmPolicyAssignmentId string = (deployLinuxPolicies && deployVmPolicies) ? linuxVmPolicyAssignment.id : ''
+output linuxVmssPolicyAssignmentId string = (deployLinuxPolicies && deployVmssPolicies) ? linuxVmssPolicyAssignment.id : ''
+output windowsVmPolicyAssignmentId string = (deployWindowsPolicies && deployVmPolicies) ? windowsVmPolicyAssignment.id : ''
+output windowsVmssPolicyAssignmentId string = (deployWindowsPolicies && deployVmssPolicies) ? windowsVmssPolicyAssignment.id : ''
+output linuxVmPolicyPrincipalId string = (deployLinuxPolicies && deployVmPolicies) ? linuxVmPolicyAssignment!.identity.principalId : ''
+output linuxVmssPolicyPrincipalId string = (deployLinuxPolicies && deployVmssPolicies) ? linuxVmssPolicyAssignment!.identity.principalId : ''
+output windowsVmPolicyPrincipalId string = (deployWindowsPolicies && deployVmPolicies) ? windowsVmPolicyAssignment!.identity.principalId : ''
+output windowsVmssPolicyPrincipalId string = (deployWindowsPolicies && deployVmssPolicies) ? windowsVmssPolicyAssignment!.identity.principalId : ''
 output managementGroupId string = managementGroup().id
 output managementGroupName string = managementGroup().name

--- a/policy/falcon-subscription.bicep
+++ b/policy/falcon-subscription.bicep
@@ -8,6 +8,14 @@ targetScope = 'subscription'
 ])
 param operatingSystem string = 'both'
 
+@description('Azure compute resource types to deploy policies for')
+@allowed([
+  'vm'
+  'vmss'
+  'both'
+])
+param resourceTypes string = 'both'
+
 @description('Policy definition name prefix')
 param policyDefinitionNamePrefix string = 'CS-Falcon-Policy'
 
@@ -56,6 +64,11 @@ param vdi bool = false
 
 // Variables
 var operatingSystemLower = toLower(operatingSystem)
+var resourceTypesLower = toLower(resourceTypes)
+var deployLinuxPolicies = operatingSystemLower == 'linux' || operatingSystemLower == 'both'
+var deployWindowsPolicies = operatingSystemLower == 'windows' || operatingSystemLower == 'both'
+var deployVmPolicies = resourceTypesLower == 'vm' || resourceTypesLower == 'both'
+var deployVmssPolicies = resourceTypesLower == 'vmss' || resourceTypesLower == 'both'
 var vmRoleDefinitionId = '9980e02c-c2be-4d73-94e8-173b1dc7cf3c' // Virtual Machine Contributor
 var linuxPolicyDefinitionName = '${policyDefinitionNamePrefix}-Linux'
 var windowsPolicyDefinitionName = '${policyDefinitionNamePrefix}-Windows'
@@ -309,7 +322,7 @@ var commonWindowsAssignmentParameters = union(commonLinuxAssignmentParameters, {
 })
 
 // Create Linux VM policy definition
-resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployLinuxPolicies && deployVmPolicies) {
   name: '${linuxPolicyDefinitionName}-VM'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMs'
@@ -403,7 +416,7 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
 }
 
 // Create Linux VMSS policy definition
-resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployLinuxPolicies && deployVmssPolicies) {
   name: '${linuxPolicyDefinitionName}-VMSS'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMSS'
@@ -497,7 +510,7 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
 }
 
 // Create Linux VM policy assignment at subscription level
-resource linuxVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployLinuxPolicies && deployVmPolicies) {
   name: 'CS-Falcon-Linux-VM-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
@@ -512,7 +525,7 @@ resource linuxVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020
 }
 
 // Create Linux VMSS policy assignment at subscription level
-resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
+resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployLinuxPolicies && deployVmssPolicies) {
   name: 'CS-Falcon-Linux-VMSS-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
@@ -527,7 +540,7 @@ resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@20
 }
 
 // Create Windows VM policy definition
-resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployWindowsPolicies && deployVmPolicies) {
   name: '${windowsPolicyDefinitionName}-VM'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMs'
@@ -626,7 +639,7 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
 }
 
 // Create Windows VMSS policy definition
-resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployWindowsPolicies && deployVmssPolicies) {
   name: '${windowsPolicyDefinitionName}-VMSS'
   properties: {
     displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMSS'
@@ -725,7 +738,7 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
 }
 
 // Create Windows VM policy assignment at subscription level
-resource windowsVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployWindowsPolicies && deployVmPolicies) {
   name: 'CS-Falcon-Windows-VM-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
@@ -740,7 +753,7 @@ resource windowsVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@20
 }
 
 // Create Windows VMSS policy assignment at subscription level
-resource windowsVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
+resource windowsVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployWindowsPolicies && deployVmssPolicies) {
   name: 'CS-Falcon-Windows-VMSS-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
@@ -755,7 +768,7 @@ resource windowsVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@
 }
 
 // Create role assignments for the policies' managed identities (at subscription scope)
-resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployLinuxPolicies && deployVmPolicies) {
   name: guid(linuxVmPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'LinuxVM')
   properties: {
     principalId: linuxVmPolicyAssignment!.identity.principalId
@@ -764,7 +777,7 @@ resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignmen
   }
 }
 
-resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployLinuxPolicies && deployVmssPolicies) {
   name: guid(linuxVmssPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'LinuxVMSS')
   properties: {
     principalId: linuxVmssPolicyAssignment!.identity.principalId
@@ -773,7 +786,7 @@ resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignm
   }
 }
 
-resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployWindowsPolicies && deployVmPolicies) {
   name: guid(windowsVmPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'WindowsVM')
   properties: {
     principalId: windowsVmPolicyAssignment!.identity.principalId
@@ -782,7 +795,7 @@ resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignm
   }
 }
 
-resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployWindowsPolicies && deployVmssPolicies) {
   name: guid(windowsVmssPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'WindowsVMSS')
   properties: {
     principalId: windowsVmssPolicyAssignment!.identity.principalId
@@ -792,17 +805,17 @@ resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssig
 }
 
 // Outputs
-output linuxVmPolicyDefinitionId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyDefinition.id : ''
-output linuxVmssPolicyDefinitionId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyDefinition.id : ''
-output windowsVmPolicyDefinitionId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyDefinition.id : ''
-output windowsVmssPolicyDefinitionId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmssPolicyDefinition.id : ''
-output linuxVmPolicyAssignmentId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyAssignment.id : ''
-output linuxVmssPolicyAssignmentId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyAssignment.id : ''
-output windowsVmPolicyAssignmentId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyAssignment.id : ''
-output windowsVmssPolicyAssignmentId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmssPolicyAssignment.id : ''
-output linuxVmPolicyPrincipalId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyAssignment!.identity.principalId : ''
-output linuxVmssPolicyPrincipalId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyAssignment!.identity.principalId : ''
-output windowsVmPolicyPrincipalId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyAssignment!.identity.principalId : ''
-output windowsVmssPolicyPrincipalId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmssPolicyAssignment!.identity.principalId : ''
+output linuxVmPolicyDefinitionId string = (deployLinuxPolicies && deployVmPolicies) ? linuxVmPolicyDefinition.id : ''
+output linuxVmssPolicyDefinitionId string = (deployLinuxPolicies && deployVmssPolicies) ? linuxVmssPolicyDefinition.id : ''
+output windowsVmPolicyDefinitionId string = (deployWindowsPolicies && deployVmPolicies) ? windowsVmPolicyDefinition.id : ''
+output windowsVmssPolicyDefinitionId string = (deployWindowsPolicies && deployVmssPolicies) ? windowsVmssPolicyDefinition.id : ''
+output linuxVmPolicyAssignmentId string = (deployLinuxPolicies && deployVmPolicies) ? linuxVmPolicyAssignment.id : ''
+output linuxVmssPolicyAssignmentId string = (deployLinuxPolicies && deployVmssPolicies) ? linuxVmssPolicyAssignment.id : ''
+output windowsVmPolicyAssignmentId string = (deployWindowsPolicies && deployVmPolicies) ? windowsVmPolicyAssignment.id : ''
+output windowsVmssPolicyAssignmentId string = (deployWindowsPolicies && deployVmssPolicies) ? windowsVmssPolicyAssignment.id : ''
+output linuxVmPolicyPrincipalId string = (deployLinuxPolicies && deployVmPolicies) ? linuxVmPolicyAssignment!.identity.principalId : ''
+output linuxVmssPolicyPrincipalId string = (deployLinuxPolicies && deployVmssPolicies) ? linuxVmssPolicyAssignment!.identity.principalId : ''
+output windowsVmPolicyPrincipalId string = (deployWindowsPolicies && deployVmPolicies) ? windowsVmPolicyAssignment!.identity.principalId : ''
+output windowsVmssPolicyPrincipalId string = (deployWindowsPolicies && deployVmssPolicies) ? windowsVmssPolicyAssignment!.identity.principalId : ''
 output subscriptionId string = subscription().subscriptionId
 output subscriptionName string = subscription().displayName


### PR DESCRIPTION
This change adds a new resourceTypes deployment parameter to the Azure Policy Bicep templates, allowing policy deployments to target:

- vm
- vmss
- both

It controls creation of the VM and VMSS policy definitions, policy assignments, managed identity role assignments, and related outputs. The policy documentation was also updated with examples for VM-only and VMSS-only deployments in README.md.
he current templates always deploy both VM and VMSS policies for the selected operating system. That makes it difficult for customers to use subscription-level or management-group-level policy deployment when they want Falcon installed on regular Azure VMs but not on VM Scale Sets.

A key example is AKS. AKS node pools are backed by VMSS resources in managed node resource groups, and installing the Falcon Azure VM extension directly on AKS node-pool VMSS is unsupported. This change gives customers a clean deployment-time option to use:
`resourceTypes="vm"`
That enables automatic Falcon sensor deployment for regular Azure VMs while preventing policy-driven installation on existing VMSS resources used by AKS or similar managed platforms.
