### PR TITLE
feat: add Azure Arc-connected server support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,11 @@ jobs:
         # Update ARM template handler versions
         sed -i 's/"extensionTypeHandlerVersion": "[^"]*"/"extensionTypeHandlerVersion": "${{ steps.version.outputs.handler_version }}"/g' linux/package/Artifacts/MainTemplate.json
         sed -i 's/"extensionTypeHandlerVersion": "[^"]*"/"extensionTypeHandlerVersion": "${{ steps.version.outputs.handler_version }}"/g' windows/package/Artifacts/MainTemplate.json
-        
+
+        # Update Arc ARM template handler versions
+        sed -i 's/"extensionTypeHandlerVersion": "[^"]*"/"extensionTypeHandlerVersion": "${{ steps.version.outputs.handler_version }}"/g' linux/package/Artifacts/MainTemplate-Arc.json
+        sed -i 's/"extensionTypeHandlerVersion": "[^"]*"/"extensionTypeHandlerVersion": "${{ steps.version.outputs.handler_version }}"/g' windows/package/Artifacts/MainTemplate-Arc.json
+
         echo "Updated all version references"
 
     - name: Generate deployment files

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ These configuration parameters can be placed in the `settings` section:
 | `azure_vault_name` | Azure Key Vault name containing CrowdStrike credentials | None |
 | `azure_managed_identity_client_id` | Azure Managed Identity Client ID for Key Vault access (used with azure_vault_name) | None |
 | `cloud` | CrowdStrike cloud region (us-1, us-2, eu-1, us-gov-1, autodiscover) | autodiscover |
-| `member_cid` | Member CID for MSSP scenarios | None |
+| `member_cid` | Member CID for MSSP Parent/child scenarios. Requires Parent API Credentials and the Child CID. | None |
 | `sensor_update_policy` | Sensor update policy name. Configure this to match your organization's desired sensor update policy instead of using the pre-defined default. | platform_default |
 | `tags` | Comma-separated list of sensor tags | None |
 | `disable_proxy` | Disable proxy settings | false |
@@ -135,6 +135,9 @@ These configuration parameters can be placed in the `settings` section:
 | `disable_start` | Prevent sensor from starting until reboot | false |
 | `provisioning_wait_time` | Provisioning timeout in milliseconds | 1200000 |
 | `vdi` | Enable virtual desktop infrastructure mode | false |
+
+> [!WARNING]
+> For Windows Azure Arc deployments, it is recommended to set `disable_provisioning_wait` to `true`. Arc enforces a 5% CPU cap on extension commands, which can cause the provisioning wait to exceed the enable command timeout. The sensor will still provision in the background after installation completes. The Windows Arc ARM template defaults this to `true`.
 
 ## Usage
 
@@ -167,6 +170,45 @@ az vm extension set \
   --settings '{
     "cloud": "autodiscover",
     "tags": "azure,production"
+  }' \
+  --protected-settings '{
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_CLIENT_SECRET"
+  }'
+```
+
+### Azure Arc
+
+#### Linux
+```bash
+az connectedmachine extension create \
+  --resource-group myResourceGroup \
+  --machine-name myArcMachine \
+  --name FalconSensorLinux \
+  --publisher Crowdstrike.Falcon \
+  --type FalconSensorLinux \
+  --settings '{
+    "cloud": "autodiscover",
+    "tags": "azure-arc,production"
+  }' \
+  --protected-settings '{
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_CLIENT_SECRET"
+  }'
+```
+
+#### Windows
+```bash
+az connectedmachine extension create \
+  --resource-group myResourceGroup \
+  --machine-name myArcMachine \
+  --name FalconSensorWindows \
+  --publisher Crowdstrike.Falcon \
+  --type FalconSensorWindows \
+  --settings '{
+    "cloud": "autodiscover",
+    "disable_provisioning_wait": "true",
+    "tags": "azure-arc,production"
   }' \
   --protected-settings '{
     "client_id": "YOUR_CLIENT_ID",
@@ -298,6 +340,25 @@ In addition to the VM logs, you can also check the extension status and configur
 
 - Check extension status in Azure portal under VM → Extensions + applications
 - Use Azure CLI: `az vm extension show --resource-group <rg> --vm-name <vm> --name FalconSensorLinux` (or `FalconSensorWindows`)
+
+### Azure Arc-Connected Machines
+
+For Azure Arc-connected machines, the log locations differ from standard Azure VMs. The GuestConfig agent manages extension paths and provides them to the handler via `HandlerEnvironment.json`. Typical base paths are:
+
+- **Logs**: `/var/lib/GuestConfig/extension_logs/Crowdstrike.Falcon.FalconSensorLinux/` (Linux) or `C:\ProgramData\GuestConfig\extension_logs\Crowdstrike.Falcon.FalconSensorWindows\` (Windows)
+- **Working directory**: `/var/lib/GuestConfig/extension_packages/Crowdstrike.Falcon.FalconSensorLinux-<version>/` (Linux) or `C:\Packages\Plugins\Crowdstrike.Falcon.FalconSensorWindows\<version>\` (Windows)
+
+Check Arc extension status via Azure CLI:
+
+```bash
+az connectedmachine extension show \
+  --resource-group <rg> \
+  --machine-name <machine> \
+  --name FalconSensorLinux
+```
+
+> [!WARNING]
+> Azure Arc enforces a default 5% CPU cap on extension commands, which can cause slower provisioning. The Arc ARM template defaults `disable_provisioning_wait` to `true` to avoid enable command timeouts. The sensor will still provision in the background after installation completes.
 
 Review these logs for failures as to why the installation and deployment failed. When contacting CrowdStrike support or creating a GitHub issue, these logs should be provided.
 

--- a/linux/handler/HandlerManifest.json
+++ b/linux/handler/HandlerManifest.json
@@ -6,6 +6,7 @@
     "updateCommand": "update.sh",
     "enableCommand": "enable.sh",
     "disableCommand": "disable.sh",
+    "resetCommand": "reset.sh",
     "rebootAfterInstall": false,
     "reportHeartbeat": false,
     "updateMode": "UpdateWithoutInstall",

--- a/linux/handler/helper.sh
+++ b/linux/handler/helper.sh
@@ -2,10 +2,30 @@
 set -euo pipefail
 
 readonly VERSION="0.0.0"
+readonly HANDLER_DIR="${script_path:?script_path must be set before sourcing helper.sh}"
+readonly MAX_LOG_SIZE=5242880  # 5 MB
+
+# Check if running in an Azure Arc environment
+is_arc_environment() {
+    if [ -f "/opt/azcmagent/bin/himds" ]; then
+        return 0
+    fi
+    return 1
+}
 
 # Get the log folder path from HandlerEnvironment.json
 get_logs_folder() {
-    LOGS_FOLDER=$(cat HandlerEnvironment.json | grep -o '"logFolder": "[^"]*"' | cut -d'"' -f4)
+    LOGS_FOLDER=$(cat "$HANDLER_DIR/HandlerEnvironment.json" | grep -o '"logFolder":[[:space:]]*"[^"]*"' | cut -d'"' -f4)
+}
+
+rotate_log() {
+    local log_file="$LOGS_FOLDER/cshandler.log"
+    if [ -f "$log_file" ]; then
+        local size=$(stat -c%s "$log_file" 2>/dev/null || stat -f%z "$log_file" 2>/dev/null || echo 0)
+        if [ "$size" -ge "$MAX_LOG_SIZE" ]; then
+            mv -f "$log_file" "${log_file}.1"
+        fi
+    fi
 }
 
 # Logging function
@@ -15,6 +35,7 @@ log() {
     local timestamp=$(date --utc --iso-8601=seconds)
 
     get_logs_folder
+    rotate_log
 
     echo "[$timestamp] $level $message"
     echo "[$timestamp] $level $message" >> "$LOGS_FOLDER/cshandler.log"
@@ -48,14 +69,52 @@ is_sensor_installed() {
 
 # Get the configuration file path from HandlerEnvironment.json
 get_config_file() {
-    local cfg_path=$(cat HandlerEnvironment.json | grep -o '"configFolder": "[^"]*"' | cut -d'"' -f4)
+    local cfg_path=$(cat "$HANDLER_DIR/HandlerEnvironment.json" | grep -o '"configFolder":[[:space:]]*"[^"]*"' | cut -d'"' -f4)
     local config_files_path="$cfg_path/*.settings"
     CONFIG_FILE=$(ls $config_files_path 2>/dev/null | sort -V | tail -1)
 }
 
 # Get the status folder path from HandlerEnvironment.json
 get_status_folder() {
-    STATUS_FOLDER=$(cat HandlerEnvironment.json | grep -o '"statusFolder": "[^"]*"' | cut -d'"' -f4)
+    STATUS_FOLDER=$(cat "$HANDLER_DIR/HandlerEnvironment.json" | grep -o '"statusFolder":[[:space:]]*"[^"]*"' | cut -d'"' -f4)
+}
+
+# Extract host and port from a proxy URL, stripping scheme and credentials
+# e.g. http://user:password@proxy:8080 -> proxy:8080
+parse_proxy_url() {
+    local url="$1"
+    local stripped="$url"
+
+    stripped="${stripped#http://}"
+    stripped="${stripped#https://}"
+
+    if [[ "$stripped" == *"@"* ]]; then
+        stripped="${stripped#*@}"
+    fi
+
+    stripped="${stripped%%/*}"
+
+    echo "$stripped"
+}
+
+# Resolve proxy configuration from the Arc agent
+get_arc_proxy_config() {
+    if [ -n "${ProxySettings:-}" ]; then
+        HTTPS_PROXY=$(parse_proxy_url "$ProxySettings")
+        log "INFO" "Using Arc proxy from ProxySettings environment variable: $HTTPS_PROXY"
+        return
+    fi
+
+    local arc_config="/var/opt/azcmagent/localconfig.json"
+    if [ -f "$arc_config" ]; then
+        local proxy_url
+        proxy_url=$(grep -o '"proxy.url": *"[^"]*"' "$arc_config" | cut -d'"' -f4 || true)
+        if [ -n "$proxy_url" ]; then
+            HTTPS_PROXY=$(parse_proxy_url "$proxy_url")
+            log "INFO" "Using Arc proxy from localconfig.json: $HTTPS_PROXY"
+            return
+        fi
+    fi
 }
 
 # Parse proxy configuration from config file
@@ -63,6 +122,14 @@ get_proxy_config() {
     PROXY_HOST=""
     PROXY_PORT=""
     HTTPS_PROXY=""
+
+    # On Arc, inherit the agent's proxy settings first
+    if is_arc_environment; then
+        get_arc_proxy_config
+        if [ -n "$HTTPS_PROXY" ]; then
+            return
+        fi
+    fi
 
     if [ -f "$CONFIG_FILE" ]; then
         # Extract proxy_host and proxy_port from settings
@@ -145,6 +212,17 @@ run_falcon_installer() {
 
     # Get Config file
     get_config_file
+
+    # Azure Arc only supports system-assigned managed identities. If a user-assigned
+    # managed identity client ID is configured, warn and clear it so the installer
+    # falls back to system-assigned identity via HIMDS challenge/response.
+    if is_arc_environment && [ -f "$CONFIG_FILE" ]; then
+        local mi_client_id
+        mi_client_id=$(grep -o '"azure_managed_identity_client_id": *"[^"]*"' "$CONFIG_FILE" | cut -d'"' -f4 | head -1 || true)
+        if [ -n "$mi_client_id" ]; then
+            log "WARN" "[$operation_upper] Azure Arc does not support user-assigned managed identities."
+        fi
+    fi
 
     # Get proxy configuration
     get_proxy_config

--- a/linux/handler/reset.sh
+++ b/linux/handler/reset.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+readonly script_path=$(dirname $(readlink -f "$0"))
+source $script_path/helper.sh
+
+log "INFO" "[RESET] Resetting extension handler state"
+
+get_status_folder
+
+if [ -d "$STATUS_FOLDER" ]; then
+    rm -f "$STATUS_FOLDER"/*.status
+    log "INFO" "[RESET] Cleared status files from $STATUS_FOLDER"
+fi
+
+log "INFO" "[RESET] Extension handler state has been reset"
+
+exit 0

--- a/linux/package/Artifacts/MainTemplate-Arc.json
+++ b/linux/package/Artifacts/MainTemplate-Arc.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "machineName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Arc-connected machine to install the extension on"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources"
+      }
+    },
+    "access-token": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Access token for accessing CrowdStrike Falcon Platform"
+      }
+    },
+    "client-id": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Client ID for accessing CrowdStrike Falcon Platform"
+      }
+    },
+    "client-secret": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Client Secret for accessing CrowdStrike Falcon Platform"
+      }
+    },
+    "cloud": {
+      "type": "string",
+      "defaultValue": "autodiscover",
+      "metadata": {
+        "description": "Falcon cloud abbreviation (e.g. us-1, us-2, eu-1, us-gov-1)"
+      }
+    },
+    "member-cid": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Member CID for MSSP (for cases when OAuth2 authenticates multiple CIDs)"
+      }
+    },
+    "sensor-update-policy": {
+      "type": "string",
+      "defaultValue": "platform_default",
+      "metadata": {
+        "description": "The sensor update policy name to use for sensor installation"
+      }
+    },
+    "disable-proxy": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Disable the sensor proxy settings"
+      }
+    },
+    "provisioning-token": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The provisioning token to use for installing the sensor. If not provided, the API will attempt to retrieve a token"
+      }
+    },
+    "azure-vault-name": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Azure Key Vault name for retrieving CrowdStrike API credentials"
+      }
+    },
+    "proxy-host": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The proxy host for the sensor to use when communicating with CrowdStrike"
+      }
+    },
+    "proxy-port": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The proxy port for the sensor to use when communicating with CrowdStrike"
+      }
+    },
+    "tags": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "A comma separated list of tags for sensor grouping"
+      }
+    }
+  },
+  "variables": {
+    "extensionName": "FalconSensorLinux",
+    "extensionPublisher": "Crowdstrike.Falcon",
+    "extensionType": "FalconSensorLinux",
+    "extensionTypeHandlerVersion": "0.0"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.HybridCompute/machines/extensions",
+      "apiVersion": "2024-07-10",
+      "name": "[concat(parameters('machineName'), '/', variables('extensionName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publisher": "[variables('extensionPublisher')]",
+        "type": "[variables('extensionType')]",
+        "typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "azure_vault_name": "[parameters('azure-vault-name')]",
+          "cloud": "[parameters('cloud')]",
+          "member_cid": "[parameters('member-cid')]",
+          "sensor_update_policy": "[parameters('sensor-update-policy')]",
+          "disable_proxy": "[parameters('disable-proxy')]",
+          "proxy_host": "[parameters('proxy-host')]",
+          "proxy_port": "[parameters('proxy-port')]",
+          "tags": "[parameters('tags')]"
+        },
+        "protectedSettings": {
+          "access_token": "[parameters('access-token')]",
+          "client_id": "[parameters('client-id')]",
+          "client_secret": "[parameters('client-secret')]",
+          "provisioning_token": "[parameters('provisioning-token')]"
+        }
+      }
+    }
+  ]
+}

--- a/linux/package/Manifest.json
+++ b/linux/package/Manifest.json
@@ -20,6 +20,12 @@
       "isDefault": true
     },
     {
+      "name": "MainTemplate-Arc",
+      "type": "Template",
+      "path": "Artifacts\\MainTemplate-Arc.json",
+      "isDefault": false
+    },
+    {
       "name": "CreateUiDefinition",
       "type": "Custom",
       "path": "Artifacts\\CreateUiDefinition.json",
@@ -40,6 +46,7 @@
     }
   ],
   "categories": [
-    "compute-vmextension-linux"
+    "compute-vmextension-linux",
+    "hybridcompute-extension-linux"
   ]
 }

--- a/linux/package/UiDefinition.json
+++ b/linux/package/UiDefinition.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://gallery.azure.com/schemas/2015-02-12/uiDefinition.json#",
+  "$schema": "https://gallery.azure.com/schemas/2018-02-12/UIDefinition.json#",
   "createDefinition": {
     "createBlade": {
-      "name": "AddVmExtension",
-      "extension": "Microsoft_Azure_Compute"
+      "name": "CreateUIDefinitionBlade",
+      "extension": "Microsoft_Azure_CreateUIDef"
     }
   }
 }

--- a/policy/README.md
+++ b/policy/README.md
@@ -26,11 +26,11 @@ The Azure Policy templates are available as part of the official CrowdStrike Azu
 ## Features
 
 ### Core Functionality
-- **Automatic Detection**: Policies detect Windows and Linux VMs and Virtual Machine Scale Sets (VMSS) automatically
+- **Automatic Detection**: Policies detect Windows and Linux VMs, Virtual Machine Scale Sets (VMSS), and Azure Arc-connected servers automatically
 - **Extension Installation**: Uses official CrowdStrike VM extensions for reliable deployment
-- **VM and VMSS Support**: Comprehensive coverage of both individual VMs and VMSS instances
+- **VM, VMSS, and Arc Support**: Comprehensive coverage of individual VMs, VMSS instances, and Arc-connected servers
 - **Managed Identity**: Secure deployment using system-assigned managed identities
-- **Role Assignment**: Automatically assigns necessary permissions for VM and VMSS extension deployment
+- **Role Assignment**: Automatically assigns necessary permissions for VM, VMSS, and Arc extension deployment
 
 ### Policy Effects
 - **DeployIfNotExists**: Automatically installs Falcon sensor if not present (default)
@@ -52,14 +52,18 @@ The Azure Policy templates are available as part of the official CrowdStrike Azu
 
 ## Policy Structure
 
-Each template creates **4 policy definitions** for comprehensive coverage:
+Each template creates up to **6 policy definitions** for comprehensive coverage:
 
 1. **Linux VM Policy** - Deploys Falcon sensor on individual Linux virtual machines
 2. **Linux VMSS Policy** - Deploys Falcon sensor on Linux Virtual Machine Scale Sets
 3. **Windows VM Policy** - Deploys Falcon sensor on individual Windows virtual machines
 4. **Windows VMSS Policy** - Deploys Falcon sensor on Windows Virtual Machine Scale Sets
+5. **Linux Arc Policy** - Deploys Falcon sensor on Linux Azure Arc-connected servers
+6. **Windows Arc Policy** - Deploys Falcon sensor on Windows Azure Arc-connected servers
 
-All policies support the same configuration parameters and authentication methods, ensuring consistent sensor deployment across your entire Azure compute infrastructure.
+The Azure Arc policies are controlled by the `deployToArc` parameter (default: `true`). Set `deployToArc=false` to skip Arc policy creation if you only need coverage for Azure-native VMs and VMSS.
+
+All policies support the same configuration parameters and authentication methods, ensuring consistent sensor deployment across your entire Azure and hybrid compute infrastructure.
 
 ## Deployment Options
 
@@ -244,13 +248,15 @@ See https://github.com/CrowdStrike/azure-vm-extension?tab=readme-ov-file#falcon-
 | `clientSecret` | securestring | OAuth2 Client Secret | '' |
 | `accessToken` | securestring | API Access Token | '' |
 | `azureVaultName` | string | Azure Key Vault name containing CrowdStrike credentials | '' |
-| `azureManagedIdentityClientId` | string | Azure Managed Identity Client ID for Key Vault access | '' |
+| `azureManagedIdentityClientId` | string | Azure Managed Identity Client ID for Key Vault access (required when `azureManagedIdentityResourceId` is set) | '' |
+| `azureManagedIdentityResourceId` | string | Full ARM resource ID of the user-assigned managed identity to attach to VMs/VMSS for Key Vault access (requires `azureManagedIdentityClientId`) | '' |
 | `cloud` | string | Falcon Cloud (us-1, us-2, eu-1, us-gov-1) | 'autodiscover' |
-| `memberCid` | string | Member CID for MSSP | '' |
+| `memberCid` | string | Member CID for MSSP. Requires Parent API Credentials and the Child CID for memberCid.| '' |
 | `sensorUpdatePolicy` | string | Sensor update policy name. Configure this to match your organization's desired sensor update policy instead of using the pre-defined default. | 'platform_default' |
 | `tags` | string | Comma-separated sensor tags | '' |
 | `policyEffect` | string | Policy effect | 'DeployIfNotExists' |
 | `createRoleAssignments` | bool | Create role assignments for managed identities | true |
+| `deployToArc` | bool | Deploy policies for Azure Arc-connected servers | true |
 | `proxySettings` | object | Network proxy configuration settings | `{proxyHost: '', proxyPort: ''}` |
 | `extensionSettings` | object | Extension configuration settings | `{handlerVersion: 'Latest release version', autoUpgradeMinorVersion: true}` |
 
@@ -275,6 +281,35 @@ See https://github.com/CrowdStrike/azure-vm-extension?tab=readme-ov-file#falcon-
 >
 > When using `azure_vault_name` with `azure_managed_identity_client_id`, the extension will use the specified user-assigned managed identity to authenticate with the Key Vault instead of the VM's system-assigned managed identity. This provides more granular control over Key Vault access permissions and is useful in scenarios where you want to use a specific managed identity for Key Vault authentication.
 
+> [!NOTE]
+> **Azure Arc limitation:** Azure Arc-connected servers only support system-assigned managed identities. The `azureManagedIdentityClientId` parameter is not used for Arc policy definitions and will be ignored on Arc servers. On Arc, the extension authenticates to Key Vault using the machine's system-assigned managed identity via the HIMDS challenge/response flow automatically.
+
+### Automatic Identity Attachment for VMs and VMSS
+
+When using Key Vault authentication with a user-assigned managed identity, the identity must be attached to the VM or VMSS before the extension can use it. The policy templates support automatic identity attachment via the `azureManagedIdentityResourceId` parameter.
+
+When `azureManagedIdentityResourceId` is provided:
+1. The policy deployment attaches the specified user-assigned identity to the VM or VMSS
+2. The extension then deploys with a `dependsOn` on the identity attachment, ensuring correct ordering
+3. The identity type is safely preserved — existing `SystemAssigned` identities are not removed
+
+**Example — Key Vault authentication with automatic identity attachment:**
+```bash
+az deployment sub create \
+  --location "East US" \
+  --template-file falcon-subscription.bicep \
+  --parameters \
+    azureVaultName="my-crowdstrike-vault" \
+    azureManagedIdentityClientId="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" \
+    azureManagedIdentityResourceId="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/crowdstrike-keyvault-identity"
+```
+
+> [!NOTE]
+> - The user-assigned managed identity resource must already exist before deploying the policy
+> - The identity must have appropriate Key Vault access (e.g., Key Vault Secrets User RBAC role or a Key Vault access policy)
+> - When `azureManagedIdentityResourceId` is provided, the policy assignment identity additionally requires the **Managed Identity Operator** role. With `createRoleAssignments=true` (default), this is created automatically at subscription scope. With `createRoleAssignments=false`, you must manually assign this role — either at subscription scope or scoped to the identity resource itself (see [Manual Role Assignment](#manual-role-assignment))
+> - This feature applies to VMs and VMSS (not Arc)
+
 ### Windows-Specific Parameters
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
@@ -294,10 +329,10 @@ See https://github.com/CrowdStrike/azure-vm-extension?tab=readme-ov-file#falcon-
 
 ### Understanding `createRoleAssignments` Parameter
 
-The templates create managed identities that need **Virtual Machine Contributor** role to deploy both VM and VMSS extensions.
+The templates create managed identities that need **Virtual Machine Contributor** role to deploy VM and VMSS extensions, and **Azure Connected Machine Resource Administrator** role for Arc-connected server extensions. When using `azureManagedIdentityResourceId` for automatic identity attachment, the **Managed Identity Operator** role is also required.
 
 > [!NOTE]
-> The **Virtual Machine Contributor** role provides sufficient permissions for both individual VM extensions (`Microsoft.Compute/virtualMachines/extensions/*`) and VMSS extensions (`Microsoft.Compute/virtualMachineScaleSets/extensions/*`). No additional role assignments are required for VMSS support.
+> The **Virtual Machine Contributor** role provides sufficient permissions for both individual VM extensions (`Microsoft.Compute/virtualMachines/extensions/*`) and VMSS extensions (`Microsoft.Compute/virtualMachineScaleSets/extensions/*`). The **Azure Connected Machine Resource Administrator** role provides permissions for Arc extensions (`Microsoft.HybridCompute/machines/extensions/*`). No additional role assignments are required.
 
 **If you have Owner or User Access Administrator role:**
 - By default, `createRoleAssignments=true` will create the necessary role assignments automatically. You do not need to take any additional action.
@@ -308,15 +343,18 @@ The templates create managed identities that need **Virtual Machine Contributor*
 
 ### Manual Role Assignment
 
-When `createRoleAssignments=false`, you must manually assign the VM Contributor role to all 4 policy managed identities:
+When `createRoleAssignments=false`, you must manually assign the VM Contributor role to the VM/VMSS policy managed identities and the Azure Connected Machine Resource Administrator role to the Arc policy managed identities:
 
 #### Azure CLI
 ```bash
+# Set deployment name
+DEPLOYMENT_NAME="YourDeploymentName"
+
 # Get all policy assignment principal IDs from deployment outputs
-LINUX_VM_PRINCIPAL_ID=$(az deployment sub show --name YourDeploymentName --query 'properties.outputs.linuxVmPolicyPrincipalId.value' -o tsv)
-LINUX_VMSS_PRINCIPAL_ID=$(az deployment sub show --name YourDeploymentName --query 'properties.outputs.linuxVmssPolicyPrincipalId.value' -o tsv)
-WINDOWS_VM_PRINCIPAL_ID=$(az deployment sub show --name YourDeploymentName --query 'properties.outputs.windowsVmPolicyPrincipalId.value' -o tsv)
-WINDOWS_VMSS_PRINCIPAL_ID=$(az deployment sub show --name YourDeploymentName --query 'properties.outputs.windowsVmssPolicyPrincipalId.value' -o tsv)
+LINUX_VM_PRINCIPAL_ID=$(az deployment sub show --name "$DEPLOYMENT_NAME" --query 'properties.outputs.linuxVmPolicyPrincipalId.value' -o tsv)
+LINUX_VMSS_PRINCIPAL_ID=$(az deployment sub show --name "$DEPLOYMENT_NAME" --query 'properties.outputs.linuxVmssPolicyPrincipalId.value' -o tsv)
+WINDOWS_VM_PRINCIPAL_ID=$(az deployment sub show --name "$DEPLOYMENT_NAME" --query 'properties.outputs.windowsVmPolicyPrincipalId.value' -o tsv)
+WINDOWS_VMSS_PRINCIPAL_ID=$(az deployment sub show --name "$DEPLOYMENT_NAME" --query 'properties.outputs.windowsVmssPolicyPrincipalId.value' -o tsv)
 
 # Assign VM Contributor role to all policy managed identities
 SUBSCRIPTION_SCOPE="/subscriptions/$(az account show --query id -o tsv)"
@@ -325,6 +363,20 @@ az role assignment create --assignee "$LINUX_VM_PRINCIPAL_ID" --role "Virtual Ma
 az role assignment create --assignee "$LINUX_VMSS_PRINCIPAL_ID" --role "Virtual Machine Contributor" --scope "$SUBSCRIPTION_SCOPE"
 az role assignment create --assignee "$WINDOWS_VM_PRINCIPAL_ID" --role "Virtual Machine Contributor" --scope "$SUBSCRIPTION_SCOPE"
 az role assignment create --assignee "$WINDOWS_VMSS_PRINCIPAL_ID" --role "Virtual Machine Contributor" --scope "$SUBSCRIPTION_SCOPE"
+
+# If deployToArc=true, also assign Arc role
+LINUX_ARC_PRINCIPAL_ID=$(az deployment sub show --name "$DEPLOYMENT_NAME" --query 'properties.outputs.linuxArcPolicyPrincipalId.value' -o tsv)
+WINDOWS_ARC_PRINCIPAL_ID=$(az deployment sub show --name "$DEPLOYMENT_NAME" --query 'properties.outputs.windowsArcPolicyPrincipalId.value' -o tsv)
+
+az role assignment create --assignee "$LINUX_ARC_PRINCIPAL_ID" --role "Azure Connected Machine Resource Administrator" --scope "$SUBSCRIPTION_SCOPE"
+az role assignment create --assignee "$WINDOWS_ARC_PRINCIPAL_ID" --role "Azure Connected Machine Resource Administrator" --scope "$SUBSCRIPTION_SCOPE"
+
+# If azureManagedIdentityResourceId is provided, also assign Managed Identity Operator role
+# This can be scoped to the subscription or narrowly to the identity resource itself
+IDENTITY_RESOURCE_ID="/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity-name>"
+
+az role assignment create --assignee "$LINUX_VM_PRINCIPAL_ID" --role "Managed Identity Operator" --scope "$IDENTITY_RESOURCE_ID"
+az role assignment create --assignee "$WINDOWS_VM_PRINCIPAL_ID" --role "Managed Identity Operator" --scope "$IDENTITY_RESOURCE_ID"
 ```
 
 #### PowerShell
@@ -343,4 +395,18 @@ New-AzRoleAssignment -ObjectId $linuxVmPrincipalId -RoleDefinitionName "Virtual 
 New-AzRoleAssignment -ObjectId $linuxVmssPrincipalId -RoleDefinitionName "Virtual Machine Contributor" -Scope $subscriptionScope
 New-AzRoleAssignment -ObjectId $windowsVmPrincipalId -RoleDefinitionName "Virtual Machine Contributor" -Scope $subscriptionScope
 New-AzRoleAssignment -ObjectId $windowsVmssPrincipalId -RoleDefinitionName "Virtual Machine Contributor" -Scope $subscriptionScope
+
+# If deployToArc=true, also assign Arc role
+$linuxArcPrincipalId = (Get-AzSubscriptionDeployment -Name $deploymentName).Outputs.linuxArcPolicyPrincipalId.Value
+$windowsArcPrincipalId = (Get-AzSubscriptionDeployment -Name $deploymentName).Outputs.windowsArcPolicyPrincipalId.Value
+
+New-AzRoleAssignment -ObjectId $linuxArcPrincipalId -RoleDefinitionName "Azure Connected Machine Resource Administrator" -Scope $subscriptionScope
+New-AzRoleAssignment -ObjectId $windowsArcPrincipalId -RoleDefinitionName "Azure Connected Machine Resource Administrator" -Scope $subscriptionScope
+
+# If azureManagedIdentityResourceId is provided, also assign Managed Identity Operator role
+# This can be scoped to the subscription or narrowly to the identity resource itself
+$identityResourceId = "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity-name>"
+
+New-AzRoleAssignment -ObjectId $linuxVmPrincipalId -RoleDefinitionName "Managed Identity Operator" -Scope $identityResourceId
+New-AzRoleAssignment -ObjectId $windowsVmPrincipalId -RoleDefinitionName "Managed Identity Operator" -Scope $identityResourceId
 ```

--- a/policy/falcon-managementgroup.bicep
+++ b/policy/falcon-managementgroup.bicep
@@ -22,6 +22,9 @@ param policyEffect string = 'DeployIfNotExists'
 @description('Create role assignments for policy managed identities (requires Owner or User Access Administrator role)')
 param createRoleAssignments bool = true
 
+@description('Deploy to Azure Arc-connected servers')
+param deployToArc bool = true
+
 @description('Extension configuration settings')
 param extensionSettings object = {
   handlerVersion: '0.0'
@@ -43,6 +46,8 @@ param disableProxy bool = false
 @secure()
 param provisioningToken string = ''
 param azureManagedIdentityClientId string = ''
+@description('Full ARM resource ID of the user-assigned managed identity to attach to VMs for Key Vault access')
+param azureManagedIdentityResourceId string = ''
 param proxySettings object = {
   proxyHost: ''
   proxyPort: ''
@@ -57,6 +62,8 @@ param vdi bool = false
 // Variables
 var operatingSystemLower = toLower(operatingSystem)
 var vmRoleDefinitionId = '9980e02c-c2be-4d73-94e8-173b1dc7cf3c' // Virtual Machine Contributor
+var arcRoleDefinitionId = 'cd570a14-e51a-42ad-bac8-bafd67325302' // Azure Connected Machine Resource Administrator
+var managedIdentityOperatorRoleId = 'f1a07417-d97a-45cb-824c-7a7467783830' // Managed Identity Operator
 var linuxPolicyDefinitionName = '${policyDefinitionNamePrefix}-Linux'
 var windowsPolicyDefinitionName = '${policyDefinitionNamePrefix}-Windows'
 
@@ -113,6 +120,14 @@ var commonParameters = {
     metadata: {
       displayName: 'Azure Managed Identity Client ID'
       description: 'Azure User Assigned Managed Identity Client ID for Key Vault access'
+    }
+    defaultValue: ''
+  }
+  azureManagedIdentityResourceId: {
+    type: 'String'
+    metadata: {
+      displayName: 'User-Assigned Managed Identity Resource ID'
+      description: 'Full ARM resource ID of the user-assigned managed identity to attach to VMs for Key Vault access'
     }
     defaultValue: ''
   }
@@ -239,6 +254,7 @@ var commonTemplateParameters = {
   accessToken: { type: 'securestring' }
   azureVaultName: { type: 'string' }
   azureManagedIdentityClientId: { type: 'string' }
+  azureManagedIdentityResourceId: { type: 'string' }
   cloud: { type: 'string' }
   memberCid: { type: 'string' }
   sensorUpdatePolicy: { type: 'string' }
@@ -265,6 +281,7 @@ var commonTemplateParameterValues = {
   accessToken: { value: '[parameters(\'accessToken\')]' }
   azureVaultName: { value: '[parameters(\'azureVaultName\')]' }
   azureManagedIdentityClientId: { value: '[parameters(\'azureManagedIdentityClientId\')]' }
+  azureManagedIdentityResourceId: { value: '[parameters(\'azureManagedIdentityResourceId\')]' }
   cloud: { value: '[parameters(\'cloud\')]' }
   memberCid: { value: '[parameters(\'memberCid\')]' }
   sensorUpdatePolicy: { value: '[parameters(\'sensorUpdatePolicy\')]' }
@@ -290,6 +307,7 @@ var commonLinuxAssignmentParameters = {
   accessToken: { value: accessToken }
   azureVaultName: { value: azureVaultName }
   azureManagedIdentityClientId: { value: azureManagedIdentityClientId }
+  azureManagedIdentityResourceId: { value: azureManagedIdentityResourceId }
   cloud: { value: cloud }
   memberCid: { value: memberCid }
   sensorUpdatePolicy: { value: sensorUpdatePolicy }
@@ -329,6 +347,10 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
             field: 'Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration'
             exists: 'true'
           }
+          {
+            field: 'Microsoft.Compute/virtualMachines/virtualMachineScaleSet.id'
+            exists: 'false'
+          }
         ]
       }
       then: {
@@ -353,6 +375,7 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
           }
           roleDefinitionIds: [
             tenantResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
+            tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
           ]
           deployment: {
             properties: {
@@ -363,10 +386,26 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
                 parameters: commonTemplateParameters
                 resources: [
                   {
+                    condition: '[not(empty(parameters(\'azureManagedIdentityResourceId\')))]'
+                    name: '[parameters(\'resourceName\')]'
+                    type: 'Microsoft.Compute/virtualMachines'
+                    apiVersion: '2023-09-01'
+                    location: '[parameters(\'location\')]'
+                    identity: {
+                      type: 'UserAssigned'
+                      userAssignedIdentities: {
+                        '[parameters(\'azureManagedIdentityResourceId\')]': {}
+                      }
+                    }
+                  }
+                  {
                     name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachines/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
+                    dependsOn: [
+                      '[parameters(\'resourceName\')]'
+                    ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
                       type: 'FalconSensorLinux'
@@ -451,6 +490,7 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
           }
           roleDefinitionIds: [
             tenantResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
+            tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
           ]
           deployment: {
             properties: {
@@ -461,10 +501,26 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
                 parameters: commonTemplateParameters
                 resources: [
                   {
+                    condition: '[not(empty(parameters(\'azureManagedIdentityResourceId\')))]'
+                    name: '[parameters(\'resourceName\')]'
+                    type: 'Microsoft.Compute/virtualMachineScaleSets'
+                    apiVersion: '2023-09-01'
+                    location: '[parameters(\'location\')]'
+                    identity: {
+                      type: 'UserAssigned'
+                      userAssignedIdentities: {
+                        '[parameters(\'azureManagedIdentityResourceId\')]': {}
+                      }
+                    }
+                  }
+                  {
                     name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachineScaleSets/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
+                    dependsOn: [
+                      '[parameters(\'resourceName\')]'
+                    ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
                       type: 'FalconSensorLinux'
@@ -551,6 +607,10 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
             field: 'Microsoft.Compute/virtualMachines/osProfile.windowsConfiguration'
             exists: 'true'
           }
+          {
+            field: 'Microsoft.Compute/virtualMachines/virtualMachineScaleSet.id'
+            exists: 'false'
+          }
         ]
       }
       then: {
@@ -575,6 +635,7 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
           }
           roleDefinitionIds: [
             tenantResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
+            tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
           ]
           deployment: {
             properties: {
@@ -585,10 +646,26 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
                 parameters: windowsTemplateParameters
                 resources: [
                   {
+                    condition: '[not(empty(parameters(\'azureManagedIdentityResourceId\')))]'
+                    name: '[parameters(\'resourceName\')]'
+                    type: 'Microsoft.Compute/virtualMachines'
+                    apiVersion: '2023-09-01'
+                    location: '[parameters(\'location\')]'
+                    identity: {
+                      type: 'UserAssigned'
+                      userAssignedIdentities: {
+                        '[parameters(\'azureManagedIdentityResourceId\')]': {}
+                      }
+                    }
+                  }
+                  {
                     name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachines/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
+                    dependsOn: [
+                      '[parameters(\'resourceName\')]'
+                    ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
                       type: 'FalconSensorWindows'
@@ -678,6 +755,7 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
           }
           roleDefinitionIds: [
             tenantResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
+            tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
           ]
           deployment: {
             properties: {
@@ -688,10 +766,26 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
                 parameters: windowsTemplateParameters
                 resources: [
                   {
+                    condition: '[not(empty(parameters(\'azureManagedIdentityResourceId\')))]'
+                    name: '[parameters(\'resourceName\')]'
+                    type: 'Microsoft.Compute/virtualMachineScaleSets'
+                    apiVersion: '2023-09-01'
+                    location: '[parameters(\'location\')]'
+                    identity: {
+                      type: 'UserAssigned'
+                      userAssignedIdentities: {
+                        '[parameters(\'azureManagedIdentityResourceId\')]': {}
+                      }
+                    }
+                  }
+                  {
                     name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachineScaleSets/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
+                    dependsOn: [
+                      '[parameters(\'resourceName\')]'
+                    ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
                       type: 'FalconSensorWindows'
@@ -799,6 +893,287 @@ resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssig
   }
 }
 
+// Managed Identity Operator role assignments for VM policies (required for identity attachment)
+resource linuxVmMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+  name: guid(linuxVmPolicyAssignment.id, managedIdentityOperatorRoleId, managementGroup().id, 'LinuxVM-MIO')
+  properties: {
+    principalId: linuxVmPolicyAssignment!.identity.principalId
+    roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource windowsVmMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+  name: guid(windowsVmPolicyAssignment.id, managedIdentityOperatorRoleId, managementGroup().id, 'WindowsVM-MIO')
+  properties: {
+    principalId: windowsVmPolicyAssignment!.identity.principalId
+    roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource linuxVmssMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+  name: guid(linuxVmssPolicyAssignment.id, managedIdentityOperatorRoleId, managementGroup().id, 'LinuxVMSS-MIO')
+  properties: {
+    principalId: linuxVmssPolicyAssignment!.identity.principalId
+    roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource windowsVmssMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+  name: guid(windowsVmssPolicyAssignment.id, managedIdentityOperatorRoleId, managementGroup().id, 'WindowsVMSS-MIO')
+  properties: {
+    principalId: windowsVmssPolicyAssignment!.identity.principalId
+    roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// ──────────────────────────────────────────────────
+// Azure Arc-connected server policy definitions
+// ──────────────────────────────────────────────────
+
+// Create Linux Arc policy definition
+resource linuxArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+  name: '${linuxPolicyDefinitionName}-Arc'
+  properties: {
+    displayName: 'Deploy CrowdStrike Falcon sensor on Linux Arc-connected servers'
+    description: 'This policy deploys CrowdStrike Falcon sensor on Linux Azure Arc-connected servers if not installed'
+    policyType: 'Custom'
+    mode: 'Indexed'
+    metadata: policyMetadata
+    parameters: commonParameters
+    policyRule: {
+      if: {
+        allOf: [
+          {
+            field: 'type'
+            equals: 'Microsoft.HybridCompute/machines'
+          }
+          {
+            field: 'Microsoft.HybridCompute/machines/osName'
+            equals: 'linux'
+          }
+        ]
+      }
+      then: {
+        effect: '[parameters(\'effect\')]'
+        details: {
+          type: 'Microsoft.HybridCompute/machines/extensions'
+          existenceCondition: {
+            allOf: [
+              {
+                field: 'Microsoft.HybridCompute/machines/extensions/publisher'
+                equals: 'Crowdstrike.Falcon'
+              }
+              {
+                field: 'Microsoft.HybridCompute/machines/extensions/type'
+                equals: 'FalconSensorLinux'
+              }
+              {
+                field: 'Microsoft.HybridCompute/machines/extensions/provisioningState'
+                equals: 'Succeeded'
+              }
+            ]
+          }
+          roleDefinitionIds: [
+            tenantResourceId('Microsoft.Authorization/roleDefinitions', arcRoleDefinitionId)
+          ]
+          deployment: {
+            properties: {
+              mode: 'incremental'
+              template: {
+                '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+                contentVersion: '1.0.0.0'
+                parameters: commonTemplateParameters
+                resources: [
+                  {
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    type: 'Microsoft.HybridCompute/machines/extensions'
+                    location: '[parameters(\'location\')]'
+                    apiVersion: '2024-07-10'
+                    properties: {
+                      publisher: 'Crowdstrike.Falcon'
+                      type: 'FalconSensorLinux'
+                      typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
+                      autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
+                      settings: {
+                        azure_vault_name: '[parameters(\'azureVaultName\')]'
+                        cloud: '[parameters(\'cloud\')]'
+                        member_cid: '[parameters(\'memberCid\')]'
+                        sensor_update_policy: '[parameters(\'sensorUpdatePolicy\')]'
+                        disable_proxy: '[parameters(\'disableProxy\')]'
+                        proxy_host: '[parameters(\'proxySettings\').proxyHost]'
+                        proxy_port: '[parameters(\'proxySettings\').proxyPort]'
+                        tags: '[parameters(\'tags\')]'
+                      }
+                      protectedSettings: {
+                        client_id: '[parameters(\'clientId\')]'
+                        client_secret: '[parameters(\'clientSecret\')]'
+                        access_token: '[parameters(\'accessToken\')]'
+                        provisioning_token: '[parameters(\'provisioningToken\')]'
+                      }
+                    }
+                  }
+                ]
+              }
+              parameters: commonTemplateParameterValues
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Create Windows Arc policy definition
+resource windowsArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+  name: '${windowsPolicyDefinitionName}-Arc'
+  properties: {
+    displayName: 'Deploy CrowdStrike Falcon sensor on Windows Arc-connected servers'
+    description: 'This policy deploys CrowdStrike Falcon sensor on Windows Azure Arc-connected servers if not installed'
+    policyType: 'Custom'
+    mode: 'Indexed'
+    metadata: policyMetadata
+    parameters: union(commonParameters, windowsSpecificParameters)
+    policyRule: {
+      if: {
+        allOf: [
+          {
+            field: 'type'
+            equals: 'Microsoft.HybridCompute/machines'
+          }
+          {
+            field: 'Microsoft.HybridCompute/machines/osName'
+            equals: 'windows'
+          }
+        ]
+      }
+      then: {
+        effect: '[parameters(\'effect\')]'
+        details: {
+          type: 'Microsoft.HybridCompute/machines/extensions'
+          existenceCondition: {
+            allOf: [
+              {
+                field: 'Microsoft.HybridCompute/machines/extensions/publisher'
+                equals: 'Crowdstrike.Falcon'
+              }
+              {
+                field: 'Microsoft.HybridCompute/machines/extensions/type'
+                equals: 'FalconSensorWindows'
+              }
+              {
+                field: 'Microsoft.HybridCompute/machines/extensions/provisioningState'
+                equals: 'Succeeded'
+              }
+            ]
+          }
+          roleDefinitionIds: [
+            tenantResourceId('Microsoft.Authorization/roleDefinitions', arcRoleDefinitionId)
+          ]
+          deployment: {
+            properties: {
+              mode: 'incremental'
+              template: {
+                '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+                contentVersion: '1.0.0.0'
+                parameters: windowsTemplateParameters
+                resources: [
+                  {
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    type: 'Microsoft.HybridCompute/machines/extensions'
+                    location: '[parameters(\'location\')]'
+                    apiVersion: '2024-07-10'
+                    properties: {
+                      publisher: 'Crowdstrike.Falcon'
+                      type: 'FalconSensorWindows'
+                      typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
+                      autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
+                      settings: {
+                        azure_vault_name: '[parameters(\'azureVaultName\')]'
+                        cloud: '[parameters(\'cloud\')]'
+                        member_cid: '[parameters(\'memberCid\')]'
+                        sensor_update_policy: '[parameters(\'sensorUpdatePolicy\')]'
+                        disable_proxy: '[parameters(\'disableProxy\')]'
+                        proxy_host: '[parameters(\'proxySettings\').proxyHost]'
+                        proxy_port: '[parameters(\'proxySettings\').proxyPort]'
+                        tags: '[parameters(\'tags\')]'
+                        pac_url: '[parameters(\'pacUrl\')]'
+                        disable_provisioning_wait: '[parameters(\'disableProvisioningWait\')]'
+                        disable_start: '[parameters(\'disableStart\')]'
+                        provisioning_wait_time: '[parameters(\'provisioningWaitTime\')]'
+                        vdi: '[parameters(\'vdi\')]'
+                      }
+                      protectedSettings: {
+                        client_id: '[parameters(\'clientId\')]'
+                        client_secret: '[parameters(\'clientSecret\')]'
+                        access_token: '[parameters(\'accessToken\')]'
+                        provisioning_token: '[parameters(\'provisioningToken\')]'
+                      }
+                    }
+                  }
+                ]
+              }
+              parameters: windowsTemplateParameterValues
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Create Linux Arc policy assignment at management group level
+resource linuxArcPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+  name: 'CS-Falcon-Linux-Arc-MG'
+  location: deployment().location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    policyDefinitionId: linuxArcPolicyDefinition.id
+    displayName: 'Deploy CrowdStrike Falcon sensor on Linux Arc-connected servers (Management Group)'
+    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Linux Arc-connected servers in the management group'
+    parameters: commonLinuxAssignmentParameters
+  }
+}
+
+// Create Windows Arc policy assignment at management group level
+resource windowsArcPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+  name: 'CS-Falcon-Win-Arc-MG'
+  location: deployment().location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    policyDefinitionId: windowsArcPolicyDefinition.id
+    displayName: 'Deploy CrowdStrike Falcon sensor on Windows Arc-connected servers (Management Group)'
+    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Windows Arc-connected servers in the management group'
+    parameters: commonWindowsAssignmentParameters
+  }
+}
+
+// Create role assignments for Arc policies' managed identities
+resource linuxArcRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
+  name: guid(linuxArcPolicyAssignment.id, arcRoleDefinitionId, managementGroup().id, 'LinuxArc')
+  properties: {
+    principalId: linuxArcPolicyAssignment!.identity.principalId
+    roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', arcRoleDefinitionId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource windowsArcRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
+  name: guid(windowsArcPolicyAssignment.id, arcRoleDefinitionId, managementGroup().id, 'WindowsArc')
+  properties: {
+    principalId: windowsArcPolicyAssignment!.identity.principalId
+    roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', arcRoleDefinitionId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
 // Outputs
 output linuxVmPolicyDefinitionId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyDefinition.id : ''
 output linuxVmssPolicyDefinitionId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyDefinition.id : ''
@@ -808,6 +1183,12 @@ output linuxVmPolicyAssignmentId string = (operatingSystemLower == 'linux' || op
 output linuxVmssPolicyAssignmentId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyAssignment.id : ''
 output windowsVmPolicyAssignmentId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyAssignment.id : ''
 output windowsVmssPolicyAssignmentId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmssPolicyAssignment.id : ''
+output linuxArcPolicyDefinitionId string = (deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) ? linuxArcPolicyDefinition.id : ''
+output windowsArcPolicyDefinitionId string = (deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) ? windowsArcPolicyDefinition.id : ''
+output linuxArcPolicyAssignmentId string = (deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) ? linuxArcPolicyAssignment.id : ''
+output windowsArcPolicyAssignmentId string = (deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) ? windowsArcPolicyAssignment.id : ''
+output linuxArcPolicyPrincipalId string = (deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) ? linuxArcPolicyAssignment!.identity.principalId : ''
+output windowsArcPolicyPrincipalId string = (deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) ? windowsArcPolicyAssignment!.identity.principalId : ''
 output linuxVmPolicyPrincipalId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmPolicyAssignment!.identity.principalId : ''
 output linuxVmssPolicyPrincipalId string = (operatingSystemLower == 'linux' || operatingSystemLower == 'both') ? linuxVmssPolicyAssignment!.identity.principalId : ''
 output windowsVmPolicyPrincipalId string = (operatingSystemLower == 'windows' || operatingSystemLower == 'both') ? windowsVmPolicyAssignment!.identity.principalId : ''

--- a/scripts/cleanup-policy.sh
+++ b/scripts/cleanup-policy.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+
+# Cleanup script for CrowdStrike Falcon Azure Policy resources
+# Dynamically discovers and removes policy assignments, definitions, and deployments
+# at both subscription and management group scope.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Default configuration
+SCOPE="subscription"
+SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-${SUBSCRIPTION_ID:-}}"
+MANAGEMENT_GROUP_ID=""
+POLICY_PREFIX="CS-Falcon"
+DRY_RUN="false"
+DELETE_DEPLOYMENTS="true"
+DEPLOYMENT_PREFIX="FALCON"
+
+# Logging functions
+log() {
+    local level=$1
+    shift
+    local color=""
+    local prefix=""
+
+    case $level in
+        "INFO") color="$BLUE"; prefix="[INFO]" ;;
+        "SUCCESS") color="$GREEN"; prefix="[SUCCESS]" ;;
+        "WARNING") color="$YELLOW"; prefix="[WARNING]" ;;
+        "ERROR") color="$RED"; prefix="[ERROR]" ;;
+    esac
+
+    echo -e "${color}${prefix}${NC} $*" >&2
+}
+
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Remove CrowdStrike Falcon Azure Policy assignments, definitions, and deployments.
+
+Resources are discovered dynamically using the policy name prefix (default: CS-Falcon).
+Deletion order: assignments → definitions → deployments (respects dependency ordering).
+
+SCOPE OPTIONS:
+  --scope SCOPE             Target scope: subscription, management-group, or both
+                            (default: subscription)
+  --subscription-id ID      Azure subscription ID
+                            (default: AZURE_SUBSCRIPTION_ID env var)
+  --management-group-id ID  Management group ID (required when scope includes
+                            management-group)
+
+FILTER OPTIONS:
+  --prefix PREFIX           Policy name prefix to match
+                            (default: CS-Falcon)
+  --deployment-prefix PFX   Deployment name prefix to match
+                            (default: FALCON)
+  --skip-deployments        Skip deletion of deployment records
+
+SAFETY OPTIONS:
+  --dry-run                 Show what would be deleted without making changes
+
+GENERAL:
+  -h, --help                Show this help message
+
+REQUIRED ENVIRONMENT VARIABLES:
+  AZURE_SUBSCRIPTION_ID     Azure subscription ID (unless --subscription-id is set)
+
+EXAMPLES:
+  # Remove all CS-Falcon policies from current subscription
+  $0
+
+  # Dry run — show what would be deleted
+  $0 --dry-run
+
+  # Remove from management group
+  $0 --scope management-group --management-group-id my-mg-id
+
+  # Remove from both subscription and management group
+  $0 --scope both --management-group-id my-mg-id
+
+  # Remove only test policies (different prefix)
+  $0 --prefix CS-Falcon-Policy-Test
+EOF
+}
+
+parse_arguments() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --scope)
+                SCOPE="$2"
+                if [[ ! "$SCOPE" =~ ^(subscription|management-group|both)$ ]]; then
+                    log ERROR "Invalid scope: $SCOPE. Must be 'subscription', 'management-group', or 'both'"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --subscription-id)
+                SUBSCRIPTION_ID="$2"
+                shift 2
+                ;;
+            --management-group-id)
+                MANAGEMENT_GROUP_ID="$2"
+                shift 2
+                ;;
+            --prefix)
+                POLICY_PREFIX="$2"
+                shift 2
+                ;;
+            --deployment-prefix)
+                DEPLOYMENT_PREFIX="$2"
+                shift 2
+                ;;
+            --skip-deployments)
+                DELETE_DEPLOYMENTS="false"
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN="true"
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                log ERROR "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+check_prerequisites() {
+    if ! command -v az &> /dev/null; then
+        log ERROR "Azure CLI is not installed"
+        exit 1
+    fi
+
+    if [[ "$SCOPE" == "subscription" || "$SCOPE" == "both" ]]; then
+        if [[ -z "$SUBSCRIPTION_ID" ]]; then
+            log ERROR "SUBSCRIPTION_ID or AZURE_SUBSCRIPTION_ID is required for subscription scope"
+            exit 1
+        fi
+    fi
+
+    if [[ "$SCOPE" == "management-group" || "$SCOPE" == "both" ]]; then
+        if [[ -z "$MANAGEMENT_GROUP_ID" ]]; then
+            log ERROR "--management-group-id is required for management-group scope"
+            exit 1
+        fi
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Subscription-scoped cleanup
+# ═══════════════════════════════════════════════════════════════════════════════
+
+delete_subscription_assignments() {
+    log INFO "Discovering policy assignments matching prefix '$POLICY_PREFIX' at subscription scope..."
+
+    # Find assignments by name prefix
+    local assignments
+    assignments=$(az policy assignment list \
+        --query "[?starts_with(name, '${POLICY_PREFIX}')].name" \
+        --output tsv 2>/dev/null) || true
+
+    # Also find assignments that reference definitions matching our prefix (handles
+    # the case where assignment names don't match the definition prefix, e.g.
+    # assignment "CS-Falcon-Linux-VM-80bcfc87" references "CS-Falcon-Policy-Test-Linux-VM")
+    local def_assignments
+    def_assignments=$(az policy assignment list \
+        --query "[?contains(policyDefinitionId, '${POLICY_PREFIX}')].name" \
+        --output tsv 2>/dev/null) || true
+
+    # Merge and deduplicate
+    local all_assignments
+    all_assignments=$(printf '%s\n%s' "$assignments" "$def_assignments" | sort -u | grep -v '^$') || true
+
+    if [[ -z "$all_assignments" ]]; then
+        log INFO "No policy assignments found matching prefix '$POLICY_PREFIX'"
+        return 0
+    fi
+
+    local count=0
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((count++))
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log INFO "[DRY RUN] Would delete policy assignment: $name"
+        else
+            log INFO "Deleting policy assignment: $name"
+            if az policy assignment delete --name "$name" --output none 2>/dev/null; then
+                log SUCCESS "Deleted assignment: $name"
+            else
+                log WARNING "Failed to delete assignment: $name (may already be removed)"
+            fi
+        fi
+    done <<< "$all_assignments"
+
+    log INFO "Processed $count subscription policy assignment(s)"
+}
+
+delete_subscription_definitions() {
+    log INFO "Discovering policy definitions matching prefix '$POLICY_PREFIX' at subscription scope..."
+
+    local definitions
+    definitions=$(az policy definition list \
+        --query "[?starts_with(name, '${POLICY_PREFIX}') && policyType == 'Custom'].name" \
+        --output tsv 2>/dev/null) || true
+
+    if [[ -z "$definitions" ]]; then
+        log INFO "No policy definitions found matching prefix '$POLICY_PREFIX'"
+        return 0
+    fi
+
+    local count=0
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((count++))
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log INFO "[DRY RUN] Would delete policy definition: $name"
+        else
+            log INFO "Deleting policy definition: $name"
+            if az policy definition delete --name "$name" --output none 2>/dev/null; then
+                log SUCCESS "Deleted definition: $name"
+            else
+                log WARNING "Failed to delete definition: $name (may have active assignments)"
+            fi
+        fi
+    done <<< "$definitions"
+
+    log INFO "Processed $count subscription policy definition(s)"
+}
+
+delete_subscription_deployments() {
+    if [[ "$DELETE_DEPLOYMENTS" != "true" ]]; then
+        return 0
+    fi
+
+    log INFO "Discovering subscription deployments matching prefix '$DEPLOYMENT_PREFIX'..."
+
+    local deployments
+    deployments=$(az deployment sub list \
+        --query "[?starts_with(name, '${DEPLOYMENT_PREFIX}')].name" \
+        --output tsv 2>/dev/null) || true
+
+    if [[ -z "$deployments" ]]; then
+        log INFO "No subscription deployments found matching prefix '$DEPLOYMENT_PREFIX'"
+        return 0
+    fi
+
+    local count=0
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((count++))
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log INFO "[DRY RUN] Would delete subscription deployment: $name"
+        else
+            log INFO "Deleting subscription deployment: $name"
+            if az deployment sub delete --name "$name" --no-wait --output none 2>/dev/null; then
+                log SUCCESS "Deleted deployment: $name"
+            else
+                log WARNING "Failed to delete deployment: $name"
+            fi
+        fi
+    done <<< "$deployments"
+
+    log INFO "Processed $count subscription deployment(s)"
+}
+
+cleanup_subscription() {
+    log INFO "Setting subscription: $SUBSCRIPTION_ID"
+    az account set -s "$SUBSCRIPTION_ID"
+
+    delete_subscription_assignments
+    delete_subscription_definitions
+    delete_subscription_deployments
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Management group-scoped cleanup
+# ═══════════════════════════════════════════════════════════════════════════════
+
+delete_management_group_assignments() {
+    log INFO "Discovering policy assignments matching prefix '$POLICY_PREFIX' at management group scope..."
+
+    local mg_scope="/providers/Microsoft.Management/managementGroups/${MANAGEMENT_GROUP_ID}"
+
+    # Find assignments by name prefix
+    local assignments
+    assignments=$(az policy assignment list \
+        --scope "$mg_scope" \
+        --query "[?starts_with(name, '${POLICY_PREFIX}')].name" \
+        --output tsv 2>/dev/null) || true
+
+    # Also find assignments that reference definitions matching our prefix
+    local def_assignments
+    def_assignments=$(az policy assignment list \
+        --scope "$mg_scope" \
+        --query "[?contains(policyDefinitionId, '${POLICY_PREFIX}')].name" \
+        --output tsv 2>/dev/null) || true
+
+    # Merge and deduplicate
+    local all_assignments
+    all_assignments=$(printf '%s\n%s' "$assignments" "$def_assignments" | sort -u | grep -v '^$') || true
+
+    if [[ -z "$all_assignments" ]]; then
+        log INFO "No policy assignments found matching prefix '$POLICY_PREFIX' at management group"
+        return 0
+    fi
+
+    local count=0
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((count++))
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log INFO "[DRY RUN] Would delete management group policy assignment: $name"
+        else
+            log INFO "Deleting management group policy assignment: $name"
+            if az policy assignment delete \
+                --name "$name" \
+                --scope "$mg_scope" \
+                --output none 2>/dev/null; then
+                log SUCCESS "Deleted assignment: $name"
+            else
+                log WARNING "Failed to delete assignment: $name (may already be removed)"
+            fi
+        fi
+    done <<< "$all_assignments"
+
+    log INFO "Processed $count management group policy assignment(s)"
+}
+
+delete_management_group_definitions() {
+    log INFO "Discovering policy definitions matching prefix '$POLICY_PREFIX' at management group scope..."
+
+    local definitions
+    definitions=$(az policy definition list \
+        --management-group "$MANAGEMENT_GROUP_ID" \
+        --query "[?starts_with(name, '${POLICY_PREFIX}') && policyType == 'Custom'].name" \
+        --output tsv 2>/dev/null) || true
+
+    if [[ -z "$definitions" ]]; then
+        log INFO "No policy definitions found matching prefix '$POLICY_PREFIX' at management group"
+        return 0
+    fi
+
+    local count=0
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((count++))
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log INFO "[DRY RUN] Would delete management group policy definition: $name"
+        else
+            log INFO "Deleting management group policy definition: $name"
+            if az policy definition delete \
+                --name "$name" \
+                --management-group "$MANAGEMENT_GROUP_ID" \
+                --output none 2>/dev/null; then
+                log SUCCESS "Deleted definition: $name"
+            else
+                log WARNING "Failed to delete definition: $name (may have active assignments)"
+            fi
+        fi
+    done <<< "$definitions"
+
+    log INFO "Processed $count management group policy definition(s)"
+}
+
+delete_management_group_deployments() {
+    if [[ "$DELETE_DEPLOYMENTS" != "true" ]]; then
+        return 0
+    fi
+
+    log INFO "Discovering management group deployments matching prefix '$DEPLOYMENT_PREFIX'..."
+
+    local deployments
+    deployments=$(az deployment mg list \
+        --management-group-id "$MANAGEMENT_GROUP_ID" \
+        --query "[?starts_with(name, '${DEPLOYMENT_PREFIX}')].name" \
+        --output tsv 2>/dev/null) || true
+
+    if [[ -z "$deployments" ]]; then
+        log INFO "No management group deployments found matching prefix '$DEPLOYMENT_PREFIX'"
+        return 0
+    fi
+
+    local count=0
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((count++))
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log INFO "[DRY RUN] Would delete management group deployment: $name"
+        else
+            log INFO "Deleting management group deployment: $name"
+            if az deployment mg delete \
+                --name "$name" \
+                --management-group-id "$MANAGEMENT_GROUP_ID" \
+                --no-wait \
+                --output none 2>/dev/null; then
+                log SUCCESS "Deleted deployment: $name"
+            else
+                log WARNING "Failed to delete deployment: $name"
+            fi
+        fi
+    done <<< "$deployments"
+
+    log INFO "Processed $count management group deployment(s)"
+}
+
+cleanup_management_group() {
+    delete_management_group_assignments
+    delete_management_group_definitions
+    delete_management_group_deployments
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════════
+
+main() {
+    parse_arguments "$@"
+    check_prerequisites
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log WARNING "DRY RUN MODE — no changes will be made"
+    fi
+
+    echo ""
+    log INFO "Policy cleanup configuration:"
+    echo "  Scope:             $SCOPE"
+    echo "  Policy prefix:     $POLICY_PREFIX"
+    echo "  Deployment prefix: $DEPLOYMENT_PREFIX"
+    echo "  Delete deployments: $DELETE_DEPLOYMENTS"
+    [[ "$SCOPE" == "subscription" || "$SCOPE" == "both" ]] && echo "  Subscription ID:   $SUBSCRIPTION_ID"
+    [[ "$SCOPE" == "management-group" || "$SCOPE" == "both" ]] && echo "  Management Group:  $MANAGEMENT_GROUP_ID"
+    echo ""
+
+    if [[ "$SCOPE" == "subscription" || "$SCOPE" == "both" ]]; then
+        log INFO "═══ Cleaning up subscription-scoped resources ═══"
+        cleanup_subscription
+        echo ""
+    fi
+
+    if [[ "$SCOPE" == "management-group" || "$SCOPE" == "both" ]]; then
+        log INFO "═══ Cleaning up management group-scoped resources ═══"
+        cleanup_management_group
+        echo ""
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log WARNING "DRY RUN complete — re-run without --dry-run to apply changes"
+    else
+        log SUCCESS "Policy cleanup complete"
+    fi
+}
+
+main "$@"

--- a/scripts/generate-deployment.sh
+++ b/scripts/generate-deployment.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # Default values
 TEST_MODE=false
 PUBLISH_MODE=false
+INTERNAL=false
 PLATFORM="all"
 VERSION=""
 REGIONS=""
@@ -24,7 +25,8 @@ Generate CrowdStrike Azure VM Extension deployment JSON files
 FLAGS:
     --test                              Generate test deployment files
     --publish                           Generate publish deployment files
-    
+    --internal                          Mark extension as internal (default: false)
+
 OPTIONS:
     -p, --platform <linux|windows|all> Platform (default: all)
     -v, --version <version>             Version number (required)
@@ -55,6 +57,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --publish)
             PUBLISH_MODE=true
+            shift
+            ;;
+        --internal)
+            INTERNAL=true
             shift
             ;;
         -p|--platform)
@@ -189,15 +195,20 @@ generate_deployment() {
     local supported_os=""
     local internal_extension=""
     
-    # Set internal extension flag based on environment
-    if [[ "$env" == "test" ]]; then
-        regions='["Central US EUAP"]'
+    # Set internal extension flag
+    if [[ "$INTERNAL" == true ]]; then
         internal_extension="true"
+    else
+        internal_extension="false"
+    fi
+
+    # Set regions based on environment
+    if [[ "$env" == "test" ]]; then
+        regions='["Central US EUAP", "East US 2 EUAP"]'
     else
         # For publish mode, use provided regions or default
         local default_array='["*"]'
         regions=$(format_regions "$REGIONS" "$default_array")
-        internal_extension="false"
     fi
     
     if [[ "$platform" == "linux" ]]; then

--- a/scripts/generate-zip.sh
+++ b/scripts/generate-zip.sh
@@ -37,7 +37,7 @@ EXAMPLES:
     $0 --test --publish -v 2.1.0       # Create both test and publish packages
 
 This script creates zip packages from the handler and package directories:
-    - Test mode: csfalcon-{platform}-handler-test-{version}.zip, csfalcon-deployment-test-{version}.zip
+    - Test mode: test{platform}extension-{version}.zip, csfalcon-deployment-test-{version}.zip
     - Publish mode: csfalcon-{platform}-handler-{version}.zip, csfalcon-{platform}-ui-{version}.zip, csfalcon-azure-policy-bicep.zip, csfalcon-deployment-{version}.zip
 EOF
 }
@@ -74,11 +74,12 @@ create_handler_package() {
     fi
     
     # Create zip file in output directory
-    local zip_suffix=""
+    local zip_name=""
     if [[ "${package_type}" == "test" ]]; then
-        zip_suffix="-test"
+        zip_name="test${platform}extension-${version}.zip"
+    else
+        zip_name="csfalcon-${platform}-handler-${version}.zip"
     fi
-    local zip_name="csfalcon-${platform}-handler${zip_suffix}-${version}.zip"
     local zip_path="${OUTPUT_DIR}/${zip_name}"
     
     echo "Generating ${zip_name}..."

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,12 +1,13 @@
 # Crowdstrike VM Extension Testing
 
-This directory contains testing tools for the Crowdstrike Falcon VM Extension that supports both Linux and Windows operating systems on VMs and VM Scale Sets (VMSS).
+This directory contains testing tools for the Crowdstrike Falcon VM Extension that supports both Linux and Windows operating systems on VMs, VM Scale Sets (VMSS), and Azure Arc-connected machines.
 
 ## Overview
 
 The testing framework allows you to:
 - Deploy VMs with the Crowdstrike Falcon extension across multiple operating systems
 - Deploy VMSS with the Crowdstrike Falcon extension (one Linux, one Windows x86_64)
+- Test the extension on existing Azure Arc-connected machines
 - Test Linux distributions (Ubuntu, Debian, RHEL, SLES) with x86_64 and arm64 architectures
 - Test Windows Server versions (2019, 2022, Core editions, Azure editions)
 - Run tests for specific platforms or all platforms
@@ -320,4 +321,110 @@ The script follows this flow:
 1. Parse command line options
 2. **VM tests**: Read and filter OS configurations from `test.config`, deploy each as a single VM
 3. **VMSS tests**: Deploy one Linux and one Windows x86_64 VMSS using fixed configurations
-4. Generate unified test summary
+4. **Arc tests**: Deploy the extension to existing Arc-connected machines and verify installation
+5. Generate unified test summary
+
+## Azure Arc Testing
+
+Arc testing validates the CrowdStrike Falcon extension on **existing** Azure Arc-connected machines. Unlike VM/VMSS tests, no infrastructure is deployed — the script targets machines that are already onboarded to Azure Arc.
+
+### Prerequisites
+
+1. **Azure CLI** with the `connectedmachine` extension installed:
+   ```bash
+   az extension add --name connectedmachine
+   ```
+2. One or more machines already connected to Azure Arc (`status == "Connected"`)
+3. The machines' resource group and names
+
+### Environment Variables
+
+```bash
+# Required for Arc tests
+export AZURE_SUBSCRIPTION_ID='your-subscription-id'
+export FALCON_CLIENT_ID='your-crowdstrike-client-id'
+export FALCON_CLIENT_SECRET='your-crowdstrike-client-secret'
+```
+
+No admin passwords are required — Arc tests do not create VMs.
+
+### Usage
+
+```bash
+# Test a single Arc machine
+./test-extension.sh --arc --arc-machine-name myArcMachine --arc-resource-group my-rg
+
+# Test multiple machines (comma-separated)
+./test-extension.sh --arc --arc-machine-name machine1,machine2 --arc-resource-group my-rg
+
+# Test multiple machines (repeated flag)
+./test-extension.sh --arc --arc-machine-name machine1 --arc-machine-name machine2 --arc-resource-group my-rg
+
+# Leave extension installed after test
+./test-extension.sh --arc --arc-machine-name myMachine --arc-resource-group my-rg --skip-cleanup
+
+# Custom timeout
+./test-extension.sh --arc --arc-machine-name myMachine --arc-resource-group my-rg --timeout 1800
+```
+
+### Arc Command Line Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--arc` | yes | - | Enable Arc testing mode |
+| `--arc-machine-name` | yes | - | Machine name(s), comma-separated or repeated |
+| `--arc-resource-group` | yes | - | Resource group containing the Arc machines |
+| `--skip-cleanup` | no | false | Leave extension installed after test |
+| `--timeout` | no | `1200` | Timeout for extension status polling (seconds) |
+
+### Test Process
+
+For each Arc machine specified, the script:
+
+1. **Verifies connectivity** — checks the machine exists and status is "Connected"
+2. **Detects OS type** — queries the machine's `osType` (Linux or Windows)
+3. **Deploys the extension** — `az connectedmachine extension create` with `disable_provisioning_wait=true`
+4. **Polls provisioning state** — checks every 30 seconds until Succeeded, Failed, or timeout
+5. **Reports result** — pass/fail per machine
+6. **Cleans up** — removes the extension (unless `--skip-cleanup`)
+
+### Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Machine not found | WARNING, skip (non-fatal) |
+| Machine not in "Connected" state | WARNING, skip (non-fatal) |
+| Extension deployment fails | ERROR, continue to next machine |
+| Extension provisioning reaches "Failed" | ERROR, continue to next machine |
+| Polling times out | ERROR, continue to next machine |
+| Cleanup fails | WARNING (non-fatal) |
+
+The script exits with code 0 if no machines failed (skips are OK), or code 1 if any machine failed.
+
+### Debugging Arc Tests
+
+```bash
+# Check Arc machine status
+az connectedmachine show \
+  --resource-group my-rg \
+  --name myMachine \
+  --query "{status:status, osType:osType}"
+
+# Check extension status on Arc machine
+az connectedmachine extension show \
+  --resource-group my-rg \
+  --machine-name myMachine \
+  --name FalconSensorLinux
+
+# List all Arc machines in a resource group
+az connectedmachine list \
+  --resource-group my-rg \
+  --query "[].{name:name, status:status, os:osType}" \
+  --output table
+```
+
+### Notes
+
+- **CPU throttling**: Arc enforces a 5% CPU cap on extensions by default. The test sets `disable_provisioning_wait=true` to avoid timeouts caused by slow installation under this cap.
+- **No parallel execution**: Azure Arc does not execute extensions in parallel on a single machine. If another extension is installing, the CrowdStrike extension will queue.
+- **Extension type**: Linux machines get `FalconSensorLinux`, Windows machines get `FalconSensorWindows` — determined automatically from the machine's OS type.

--- a/tests/test-extension.sh
+++ b/tests/test-extension.sh
@@ -29,6 +29,12 @@ CLEANUP_AFTER_TEST="true"
 WAIT_TIMEOUT=1200
 DEPLOYMENT_TYPE="both"
 AZURE_DEBUG="false"
+ARC_MODE="false"
+
+# Arc-specific settings
+ARC_MACHINE_NAMES=()
+ARC_RESOURCE_GROUP=""
+ARC_SKIP_CLEANUP="false"
 
 # Colors for output
 RED='\033[0;31m'
@@ -173,6 +179,24 @@ parse_arguments() {
                 AZURE_DEBUG="true"
                 shift
                 ;;
+            --arc)
+                ARC_MODE="true"
+                shift
+                ;;
+            --arc-machine-name)
+                IFS=',' read -ra _arc_names <<< "$2"
+                ARC_MACHINE_NAMES+=("${_arc_names[@]}")
+                shift 2
+                ;;
+            --arc-resource-group)
+                ARC_RESOURCE_GROUP="$2"
+                shift 2
+                ;;
+            --skip-cleanup)
+                ARC_SKIP_CLEANUP="true"
+                CLEANUP_AFTER_TEST="false"
+                shift
+                ;;
             -h|--help)
                 usage
                 exit 0
@@ -295,7 +319,20 @@ check_prerequisites() {
         fi
     done
 
-    # Check OS-specific passwords
+    # Check Arc-specific prerequisites
+    if [[ "$ARC_MODE" == "true" ]]; then
+        if [[ ${#ARC_MACHINE_NAMES[@]} -eq 0 ]]; then
+            log ERROR "--arc-machine-name is required in Arc mode"
+            exit 1
+        fi
+        if [[ -z "$ARC_RESOURCE_GROUP" ]]; then
+            log ERROR "--arc-resource-group is required in Arc mode"
+            exit 1
+        fi
+        log SUCCESS "Prerequisites check passed"
+        return
+    fi
+
     if [[ "$OS_TYPE" == "linux" || "$OS_TYPE" == "both" ]]; then
         validate_param "LINUX_ADMIN_PASSWORD" "$LINUX_ADMIN_PASSWORD" || exit 1
     fi
@@ -423,6 +460,194 @@ check_extension_status() {
 
     log ERROR "Extension status check timed out"
     return 1
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Azure Arc Extension Testing Functions
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Verify that an Arc machine exists and is connected
+check_arc_machine_connectivity() {
+    local resource_group=$1
+    local machine_name=$2
+
+    log INFO "Checking Arc connectivity for machine: $machine_name"
+
+    local status err
+    err=$(mktemp)
+    status=$(run_az_command connectedmachine show \
+        --resource-group "$resource_group" \
+        --name "$machine_name" \
+        --query "status" \
+        --output tsv 2>"$err") || {
+        local error_detail
+        error_detail=$(cat "$err")
+        rm -f "$err"
+        log WARNING "Failed to query machine '$machine_name' in resource group '$resource_group'"
+        [[ -n "$error_detail" ]] && log WARNING "$error_detail"
+        return 1
+    }
+    rm -f "$err"
+
+    if [[ "$status" == "Connected" ]]; then
+        log SUCCESS "Machine '$machine_name' is connected to Arc"
+        return 0
+    else
+        log WARNING "Machine '$machine_name' status is '$status' (expected 'Connected')"
+        return 1
+    fi
+}
+
+# Determine OS type of an Arc-connected machine
+get_arc_machine_os_type() {
+    local resource_group=$1
+    local machine_name=$2
+
+    run_az_command connectedmachine show \
+        --resource-group "$resource_group" \
+        --name "$machine_name" \
+        --query "osType" \
+        --output tsv 2>/dev/null || echo "Unknown"
+}
+
+# Deploy the CrowdStrike extension to an Arc-connected machine
+deploy_arc_extension() {
+    local resource_group=$1
+    local machine_name=$2
+    local os_type=$3
+
+    local extension_type
+    if [[ "$os_type" == "Linux" || "$os_type" == "linux" ]]; then
+        extension_type="TestFalconSensorLinux"
+    else
+        extension_type="TestFalconSensorWindows"
+    fi
+
+    local settings='{"disable_provisioning_wait":"true"}'
+    local protected_settings="{\"client_id\":\"$FALCON_CLIENT_ID\",\"client_secret\":\"$FALCON_CLIENT_SECRET\",\"tags\":\"arcextensiontest\",\"sensor_update_policy\":\"$SENSOR_UPDATE_POLICY\"}"
+
+    log INFO "Deploying extension '$extension_type' to Arc machine '$machine_name'..."
+
+    if run_az_command connectedmachine extension create \
+        --resource-group "$resource_group" \
+        --machine-name "$machine_name" \
+        --name "$extension_type" \
+        --publisher "$EXTENSION_PUBLISHER" \
+        --type "$extension_type" \
+        --settings "$settings" \
+        --protected-settings "$protected_settings" \
+        --no-wait \
+        --output none; then
+        log SUCCESS "Extension deployment initiated for '$machine_name'"
+        return 0
+    else
+        log ERROR "Failed to initiate extension deployment for '$machine_name'"
+        return 1
+    fi
+}
+
+# Poll extension provisioning state on an Arc machine
+check_arc_extension_status() {
+    local resource_group=$1
+    local machine_name=$2
+    local extension_name=$3
+    local deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+    local attempt=1
+
+    log INFO "Checking Arc extension status for machine: $machine_name (timeout: ${WAIT_TIMEOUT}s)"
+
+    while [[ $(date +%s) -lt $deadline ]]; do
+        local status
+        status=$(run_az_command connectedmachine extension show \
+            --resource-group "$resource_group" \
+            --machine-name "$machine_name" \
+            --name "$extension_name" \
+            --query "properties.provisioningState" \
+            --output tsv 2>/dev/null || echo "NotFound")
+
+        case $status in
+            "Succeeded")
+                log SUCCESS "Arc extension installed successfully on '$machine_name'"
+                return 0
+                ;;
+            "Failed")
+                log ERROR "Arc extension installation failed on '$machine_name'"
+                local error_msg
+                error_msg=$(run_az_command connectedmachine extension show \
+                    --resource-group "$resource_group" \
+                    --machine-name "$machine_name" \
+                    --name "$extension_name" \
+                    --query "properties.instanceView.status.message" \
+                    --output tsv 2>/dev/null || echo "")
+                [[ -n "$error_msg" ]] && log ERROR "Error details: $error_msg"
+                return 1
+                ;;
+            "Creating"|"Updating")
+                log INFO "Extension provisioning in progress (attempt $attempt)..."
+                sleep 30
+                ((attempt++))
+                ;;
+            "NotFound")
+                log WARNING "Extension not found yet (attempt $attempt)..."
+                sleep 30
+                ((attempt++))
+                ;;
+            *)
+                log WARNING "Unknown extension status: $status (attempt $attempt)..."
+                sleep 30
+                ((attempt++))
+                ;;
+        esac
+    done
+
+    log ERROR "Arc extension status check timed out for '$machine_name'"
+    return 1
+}
+
+# Remove the CrowdStrike extension from an Arc machine and wait for removal
+cleanup_arc_extension() {
+    local resource_group=$1
+    local machine_name=$2
+    local extension_name=$3
+
+    if [[ "$ARC_SKIP_CLEANUP" == "true" ]]; then
+        log WARNING "Skipping cleanup for '$machine_name' (--skip-cleanup enabled)"
+        return 0
+    fi
+
+    log INFO "Removing extension '$extension_name' from Arc machine '$machine_name'..."
+
+    if ! run_az_command connectedmachine extension delete \
+        --resource-group "$resource_group" \
+        --machine-name "$machine_name" \
+        --name "$extension_name" \
+        --yes \
+        --no-wait \
+        --output none; then
+        log WARNING "Failed to remove extension from '$machine_name' (non-fatal)"
+        return 0
+    fi
+
+    # Wait for extension to be fully removed
+    local deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+    local attempt=1
+
+    while [[ $(date +%s) -lt $deadline ]]; do
+        if ! run_az_command connectedmachine extension show \
+            --resource-group "$resource_group" \
+            --machine-name "$machine_name" \
+            --name "$extension_name" \
+            --output none 2>/dev/null; then
+            log SUCCESS "Extension removed from '$machine_name'"
+            return 0
+        fi
+        log INFO "Waiting for extension removal (attempt $attempt)..."
+        sleep 30
+        ((attempt++))
+    done
+
+    log WARNING "Extension removal timed out for '$machine_name' (non-fatal)"
+    return 0
 }
 
 # Generate VMSS parameters file from template
@@ -619,6 +844,17 @@ generate_parameters_file() {
     sed_inplace "s/$(escape_for_sed "\"0001-com-ubuntu-server-jammy\"")/$(escape_for_sed "\"$offer\"")/g" "$temp_params"
     sed_inplace "s/$(escape_for_sed "\"22_04-lts-gen2\"")/$(escape_for_sed "\"$sku\"")/g" "$temp_params"
     sed_inplace "s/$(escape_for_sed "\"x86_64\"")/$(escape_for_sed "\"${version_or_arch:-x86_64}\"")/g" "$temp_params"
+
+    # Arc-specific replacements
+    if [[ "$ARC_MODE" == "true" ]]; then
+        local machine_name="arc-${vm_name}"
+        local computer_name
+        computer_name=$(echo "$vm_name" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9' | head -c 15)
+        sed_inplace "s/$(escape_for_sed "cstest-arc")/$(escape_for_sed "$machine_name")/g" "$temp_params"
+        sed_inplace "s/$(escape_for_sed "cstestarc")/$(escape_for_sed "$computer_name")/g" "$temp_params"
+        sed_inplace "s/$(escape_for_sed "REPLACE_WITH_ARC_SP_ID")/$(escape_for_sed "$ARC_SERVICE_PRINCIPAL_ID")/g" "$temp_params"
+        sed_inplace "s/$(escape_for_sed "REPLACE_WITH_ARC_SP_SECRET")/$(escape_for_sed "$ARC_SERVICE_PRINCIPAL_SECRET")/g" "$temp_params"
+    fi
 }
 
 # Deploy and test configuration
@@ -915,6 +1151,96 @@ run_tests() {
     fi
 }
 
+# Run Arc extension tests against existing connected machines
+run_arc_tests() {
+    local total_machines=${#ARC_MACHINE_NAMES[@]}
+    local passed_tests=0
+    local failed_tests=0
+    local skipped_tests=0
+    local start_time=$(date +%s)
+
+    log INFO "Starting Azure Arc Extension Testing"
+    log INFO "Machines: $total_machines, Resource Group: $ARC_RESOURCE_GROUP"
+    log INFO "Cleanup: $([[ "$ARC_SKIP_CLEANUP" == "true" ]] && echo "disabled" || echo "enabled")"
+    echo ""
+
+    log INFO "Machines to test:"
+    for machine in "${ARC_MACHINE_NAMES[@]}"; do
+        echo "  - $machine"
+    done
+    echo ""
+
+    for machine in "${ARC_MACHINE_NAMES[@]}"; do
+        echo "═══════════════════════════════════════════════════"
+        log INFO "Testing Arc machine: $machine"
+
+        # Step 1: Verify connectivity
+        if ! check_arc_machine_connectivity "$ARC_RESOURCE_GROUP" "$machine"; then
+            log WARNING "Skipping '$machine' — not connected to Arc"
+            ((skipped_tests++))
+            echo ""
+            continue
+        fi
+
+        # Step 2: Determine OS type
+        local os_type
+        os_type=$(get_arc_machine_os_type "$ARC_RESOURCE_GROUP" "$machine")
+        log INFO "Detected OS type: $os_type"
+
+        local extension_name
+        if [[ "$os_type" == "Linux" || "$os_type" == "linux" ]]; then
+            extension_name="TestFalconSensorLinux"
+        else
+            extension_name="TestFalconSensorWindows"
+        fi
+
+        # Step 3: Deploy extension
+        if ! deploy_arc_extension "$ARC_RESOURCE_GROUP" "$machine" "$os_type"; then
+            log ERROR "❌ Arc machine '$machine': Extension deployment FAILED"
+            ((failed_tests++))
+            echo ""
+            continue
+        fi
+
+        # Step 4: Poll for provisioning state
+        if check_arc_extension_status "$ARC_RESOURCE_GROUP" "$machine" "$extension_name"; then
+            log SUCCESS "✅ Arc machine '$machine': Extension test PASSED"
+            ((passed_tests++))
+        else
+            log ERROR "❌ Arc machine '$machine': Extension test FAILED"
+            ((failed_tests++))
+        fi
+
+        # Step 5: Cleanup
+        cleanup_arc_extension "$ARC_RESOURCE_GROUP" "$machine" "$extension_name"
+        echo ""
+    done
+
+    # Summary
+    local end_time=$(date +%s)
+    local total_duration=$((end_time - start_time))
+    local total_minutes=$((total_duration / 60))
+    local remaining_seconds=$((total_duration % 60))
+
+    echo "═══════════════════════════════════════════════════"
+    log INFO "ARC TEST SUMMARY"
+    echo "Total machines: $total_machines, Passed: $passed_tests, Failed: $failed_tests, Skipped: $skipped_tests"
+    echo "Duration: ${total_minutes}m ${remaining_seconds}s"
+    echo ""
+
+    if [[ $failed_tests -eq 0 ]]; then
+        if [[ $skipped_tests -gt 0 ]]; then
+            log WARNING "All reachable machines passed ($skipped_tests skipped)"
+        else
+            log SUCCESS "🎉 All Arc tests passed!"
+        fi
+        return 0
+    else
+        log ERROR "💥 $failed_tests Arc test(s) failed"
+        return 1
+    fi
+}
+
 # Print usage
 usage() {
     cat << EOF
@@ -944,6 +1270,16 @@ FILE OPTIONS:
   --config PATH             Path to test configuration file
                             (default: ./test.config)
 
+ARC OPTIONS:
+  --arc                     Enable Azure Arc mode (test existing Arc machines)
+  --arc-machine-name NAME   Name of Arc-connected machine to test. Accepts
+                            comma-separated values or repeated flags for multiple
+                            machines. Required in Arc mode.
+  --arc-resource-group RG   Resource group containing the Arc machine(s).
+                            Required in Arc mode.
+  --skip-cleanup            Leave extension installed after test
+                            (default: uninstall after test)
+
 ADVANCED OPTIONS:
   --subscription-id ID      Azure subscription ID
                             (default: AZURE_SUBSCRIPTION_ID env var)
@@ -955,8 +1291,8 @@ REQUIRED ENVIRONMENT VARIABLES:
   AZURE_SUBSCRIPTION_ID     Azure subscription ID
   FALCON_CLIENT_ID          Crowdstrike API client ID
   FALCON_CLIENT_SECRET      Crowdstrike API client secret
-  LINUX_ADMIN_PASSWORD      Linux VM admin password (for Linux tests)
-  WINDOWS_ADMIN_PASSWORD    Windows VM admin password (for Windows tests)
+  LINUX_ADMIN_PASSWORD      Linux VM admin password (for VM/VMSS tests)
+  WINDOWS_ADMIN_PASSWORD    Windows VM admin password (for VM/VMSS tests)
 
 EXAMPLES:
   # Test both VM and VMSS for all operating systems (default)
@@ -985,6 +1321,15 @@ EXAMPLES:
 
   # Test with custom config file
   $0 --config ./custom-test.config
+
+  # Test extension on an existing Arc-connected machine
+  $0 --arc --arc-machine-name myArcMachine --arc-resource-group my-rg
+
+  # Test multiple Arc machines
+  $0 --arc --arc-machine-name machine1,machine2 --arc-resource-group my-rg
+
+  # Test Arc machine without cleanup
+  $0 --arc --arc-machine-name myMachine --arc-resource-group my-rg --skip-cleanup
 EOF
 }
 
@@ -996,12 +1341,16 @@ main() {
 
     local exit_code=0
 
-    if [[ "$DEPLOYMENT_TYPE" == "vm" || "$DEPLOYMENT_TYPE" == "both" ]]; then
-        run_tests || exit_code=1
-    fi
+    if [[ "$ARC_MODE" == "true" ]]; then
+        run_arc_tests || exit_code=1
+    else
+        if [[ "$DEPLOYMENT_TYPE" == "vm" || "$DEPLOYMENT_TYPE" == "both" ]]; then
+            run_tests || exit_code=1
+        fi
 
-    if [[ "$DEPLOYMENT_TYPE" == "vmss" || "$DEPLOYMENT_TYPE" == "both" ]]; then
-        run_vmss_tests || exit_code=1
+        if [[ "$DEPLOYMENT_TYPE" == "vmss" || "$DEPLOYMENT_TYPE" == "both" ]]; then
+            run_vmss_tests || exit_code=1
+        fi
     fi
 
     exit $exit_code

--- a/tests/test-subscription-policy.bicep
+++ b/tests/test-subscription-policy.bicep
@@ -9,7 +9,7 @@ targetScope = 'subscription'
 param operatingSystem string = 'both'
 
 @description('Policy definition name prefix')
-param policyDefinitionNamePrefix string = 'CS-Falcon-Policy'
+param policyDefinitionNamePrefix string = 'CS-Falcon-Policy-Test'
 
 @description('Effect for the policy assignment (DeployIfNotExists, AuditIfNotExists, Disabled)')
 @allowed([
@@ -330,8 +330,8 @@ var commonWindowsAssignmentParameters = union(commonLinuxAssignmentParameters, {
 resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
   name: '${linuxPolicyDefinitionName}-VM'
   properties: {
-    displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMs'
-    description: 'This policy deploys CrowdStrike Falcon sensor on Linux VMs if not installed'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Linux VMs'
+    description: 'Test policy - deploys CrowdStrike Falcon test extension on Linux VMs if not installed'
     policyType: 'Custom'
     mode: 'Indexed'
     metadata: policyMetadata
@@ -365,7 +365,7 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
               }
               {
                 field: 'Microsoft.Compute/virtualMachines/extensions/type'
-                equals: 'FalconSensorLinux'
+                equals: 'TestFalconSensorLinux'
               }
               {
                 field: 'Microsoft.Compute/virtualMachines/extensions/provisioningState'
@@ -399,7 +399,7 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
                     }
                   }
                   {
-                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeTestFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachines/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
@@ -408,7 +408,7 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
                     ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
-                      type: 'FalconSensorLinux'
+                      type: 'TestFalconSensorLinux'
                       typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
                       autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
                       settings: {
@@ -445,8 +445,8 @@ resource linuxVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020
 resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
   name: '${linuxPolicyDefinitionName}-VMSS'
   properties: {
-    displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMSS'
-    description: 'This policy deploys CrowdStrike Falcon sensor on Linux Virtual Machine Scale Sets if not installed'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Linux VMSS'
+    description: 'Test policy - deploys CrowdStrike Falcon test extension on Linux Virtual Machine Scale Sets if not installed'
     policyType: 'Custom'
     mode: 'Indexed'
     metadata: policyMetadata
@@ -480,7 +480,7 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
               }
               {
                 field: 'Microsoft.Compute/virtualMachineScaleSets/extensions/type'
-                equals: 'FalconSensorLinux'
+                equals: 'TestFalconSensorLinux'
               }
               {
                 field: 'Microsoft.Compute/virtualMachineScaleSets/extensions/provisioningState'
@@ -514,7 +514,7 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
                     }
                   }
                   {
-                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeTestFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachineScaleSets/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
@@ -523,7 +523,7 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
                     ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
-                      type: 'FalconSensorLinux'
+                      type: 'TestFalconSensorLinux'
                       typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
                       autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
                       settings: {
@@ -558,30 +558,30 @@ resource linuxVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
 
 // Create Linux VM policy assignment at subscription level
 resource linuxVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
-  name: 'CS-Falcon-Linux-VM-${take(subscription().subscriptionId, 8)}'
+  name: 'CS-Test-Linux-VM-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     policyDefinitionId: linuxVmPolicyDefinition.id
-    displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMs (Subscription)'
-    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Linux VMs in the subscription'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Linux VMs (Subscription)'
+    description: 'Test policy - ensures CrowdStrike Falcon test extension is installed on all Linux VMs in the subscription'
     parameters: commonLinuxAssignmentParameters
   }
 }
 
 // Create Linux VMSS policy assignment at subscription level
 resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'linux' || operatingSystemLower == 'both') {
-  name: 'CS-Falcon-Linux-VMSS-${take(subscription().subscriptionId, 8)}'
+  name: 'CS-Test-Linux-VMSS-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     policyDefinitionId: linuxVmssPolicyDefinition.id
-    displayName: 'Deploy CrowdStrike Falcon sensor on Linux VMSS (Subscription)'
-    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Linux VMSS in the subscription'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Linux VMSS (Subscription)'
+    description: 'Test policy - ensures CrowdStrike Falcon test extension is installed on all Linux VMSS in the subscription'
     parameters: commonLinuxAssignmentParameters
   }
 }
@@ -590,8 +590,8 @@ resource linuxVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@20
 resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
   name: '${windowsPolicyDefinitionName}-VM'
   properties: {
-    displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMs'
-    description: 'This policy deploys CrowdStrike Falcon sensor on Windows VMs if not installed'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Windows VMs'
+    description: 'Test policy - deploys CrowdStrike Falcon test extension on Windows VMs if not installed'
     policyType: 'Custom'
     mode: 'Indexed'
     metadata: policyMetadata
@@ -625,7 +625,7 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
               }
               {
                 field: 'Microsoft.Compute/virtualMachines/extensions/type'
-                equals: 'FalconSensorWindows'
+                equals: 'TestFalconSensorWindows'
               }
               {
                 field: 'Microsoft.Compute/virtualMachines/extensions/provisioningState'
@@ -659,7 +659,7 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
                     }
                   }
                   {
-                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeTestFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachines/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
@@ -668,7 +668,7 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
                     ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
-                      type: 'FalconSensorWindows'
+                      type: 'TestFalconSensorWindows'
                       typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
                       autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
                       settings: {
@@ -710,8 +710,8 @@ resource windowsVmPolicyDefinition 'Microsoft.Authorization/policyDefinitions@20
 resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
   name: '${windowsPolicyDefinitionName}-VMSS'
   properties: {
-    displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMSS'
-    description: 'This policy deploys CrowdStrike Falcon sensor on Windows Virtual Machine Scale Sets if not installed'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Windows VMSS'
+    description: 'Test policy - deploys CrowdStrike Falcon test extension on Windows Virtual Machine Scale Sets if not installed'
     policyType: 'Custom'
     mode: 'Indexed'
     metadata: policyMetadata
@@ -745,7 +745,7 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
               }
               {
                 field: 'Microsoft.Compute/virtualMachineScaleSets/extensions/type'
-                equals: 'FalconSensorWindows'
+                equals: 'TestFalconSensorWindows'
               }
               {
                 field: 'Microsoft.Compute/virtualMachineScaleSets/extensions/provisioningState'
@@ -779,7 +779,7 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
                     }
                   }
                   {
-                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeTestFalconSensor\')]'
                     type: 'Microsoft.Compute/virtualMachineScaleSets/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2021-07-01'
@@ -788,7 +788,7 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
                     ]
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
-                      type: 'FalconSensorWindows'
+                      type: 'TestFalconSensorWindows'
                       typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
                       autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
                       settings: {
@@ -828,37 +828,37 @@ resource windowsVmssPolicyDefinition 'Microsoft.Authorization/policyDefinitions@
 
 // Create Windows VM policy assignment at subscription level
 resource windowsVmPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
-  name: 'CS-Falcon-Windows-VM-${take(subscription().subscriptionId, 8)}'
+  name: 'CS-Test-Windows-VM-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     policyDefinitionId: windowsVmPolicyDefinition.id
-    displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMs (Subscription)'
-    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Windows VMs in the subscription'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Windows VMs (Subscription)'
+    description: 'Test policy - ensures CrowdStrike Falcon test extension is installed on all Windows VMs in the subscription'
     parameters: commonWindowsAssignmentParameters
   }
 }
 
 // Create Windows VMSS policy assignment at subscription level
 resource windowsVmssPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (operatingSystemLower == 'windows' || operatingSystemLower == 'both') {
-  name: 'CS-Falcon-Windows-VMSS-${take(subscription().subscriptionId, 8)}'
+  name: 'CS-Test-Windows-VMSS-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     policyDefinitionId: windowsVmssPolicyDefinition.id
-    displayName: 'Deploy CrowdStrike Falcon sensor on Windows VMSS (Subscription)'
-    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Windows VMSS in the subscription'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Windows VMSS (Subscription)'
+    description: 'Test policy - ensures CrowdStrike Falcon test extension is installed on all Windows VMSS in the subscription'
     parameters: commonWindowsAssignmentParameters
   }
 }
 
 // Create role assignments for the policies' managed identities (at subscription scope)
 resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
-  name: guid(linuxVmPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'LinuxVM')
+  name: guid(linuxVmPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'TestLinuxVM')
   properties: {
     principalId: linuxVmPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
@@ -867,7 +867,7 @@ resource linuxVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignmen
 }
 
 resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
-  name: guid(linuxVmssPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'LinuxVMSS')
+  name: guid(linuxVmssPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'TestLinuxVMSS')
   properties: {
     principalId: linuxVmssPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
@@ -876,7 +876,7 @@ resource linuxVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignm
 }
 
 resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
-  name: guid(windowsVmPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'WindowsVM')
+  name: guid(windowsVmPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'TestWindowsVM')
   properties: {
     principalId: windowsVmPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
@@ -885,7 +885,7 @@ resource windowsVmContributorRoleAssignment 'Microsoft.Authorization/roleAssignm
 }
 
 resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
-  name: guid(windowsVmssPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'WindowsVMSS')
+  name: guid(windowsVmssPolicyAssignment.id, vmRoleDefinitionId, subscription().id, 'TestWindowsVMSS')
   properties: {
     principalId: windowsVmssPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', vmRoleDefinitionId)
@@ -895,7 +895,7 @@ resource windowsVmssContributorRoleAssignment 'Microsoft.Authorization/roleAssig
 
 // Managed Identity Operator role assignments for VM policies (required for identity attachment)
 resource linuxVmMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
-  name: guid(linuxVmPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'LinuxVM-MIO')
+  name: guid(linuxVmPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'TestLinuxVM-MIO')
   properties: {
     principalId: linuxVmPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
@@ -904,7 +904,7 @@ resource linuxVmMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-
 }
 
 resource windowsVmMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
-  name: guid(windowsVmPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'WindowsVM-MIO')
+  name: guid(windowsVmPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'TestWindowsVM-MIO')
   properties: {
     principalId: windowsVmPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
@@ -913,7 +913,7 @@ resource windowsVmMioRoleAssignment 'Microsoft.Authorization/roleAssignments@202
 }
 
 resource linuxVmssMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
-  name: guid(linuxVmssPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'LinuxVMSS-MIO')
+  name: guid(linuxVmssPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'TestLinuxVMSS-MIO')
   properties: {
     principalId: linuxVmssPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
@@ -922,7 +922,7 @@ resource linuxVmssMioRoleAssignment 'Microsoft.Authorization/roleAssignments@202
 }
 
 resource windowsVmssMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && !empty(azureManagedIdentityResourceId) && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
-  name: guid(windowsVmssPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'WindowsVMSS-MIO')
+  name: guid(windowsVmssPolicyAssignment.id, managedIdentityOperatorRoleId, subscription().id, 'TestWindowsVMSS-MIO')
   properties: {
     principalId: windowsVmssPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityOperatorRoleId)
@@ -938,8 +938,8 @@ resource windowsVmssMioRoleAssignment 'Microsoft.Authorization/roleAssignments@2
 resource linuxArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
   name: '${linuxPolicyDefinitionName}-Arc'
   properties: {
-    displayName: 'Deploy CrowdStrike Falcon sensor on Linux Arc-connected servers'
-    description: 'This policy deploys CrowdStrike Falcon sensor on Linux Azure Arc-connected servers if not installed'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Linux Arc-connected servers'
+    description: 'Test policy - deploys CrowdStrike Falcon test extension on Linux Azure Arc-connected servers if not installed'
     policyType: 'Custom'
     mode: 'Indexed'
     metadata: policyMetadata
@@ -969,7 +969,7 @@ resource linuxArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@202
               }
               {
                 field: 'Microsoft.HybridCompute/machines/extensions/type'
-                equals: 'FalconSensorLinux'
+                equals: 'TestFalconSensorLinux'
               }
               {
                 field: 'Microsoft.HybridCompute/machines/extensions/provisioningState'
@@ -989,13 +989,13 @@ resource linuxArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@202
                 parameters: commonTemplateParameters
                 resources: [
                   {
-                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeTestFalconSensor\')]'
                     type: 'Microsoft.HybridCompute/machines/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2024-07-10'
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
-                      type: 'FalconSensorLinux'
+                      type: 'TestFalconSensorLinux'
                       typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
                       autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
                       settings: {
@@ -1031,8 +1031,8 @@ resource linuxArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@202
 resource windowsArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01' = if (deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
   name: '${windowsPolicyDefinitionName}-Arc'
   properties: {
-    displayName: 'Deploy CrowdStrike Falcon sensor on Windows Arc-connected servers'
-    description: 'This policy deploys CrowdStrike Falcon sensor on Windows Azure Arc-connected servers if not installed'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Windows Arc-connected servers'
+    description: 'Test policy - deploys CrowdStrike Falcon test extension on Windows Azure Arc-connected servers if not installed'
     policyType: 'Custom'
     mode: 'Indexed'
     metadata: policyMetadata
@@ -1062,7 +1062,7 @@ resource windowsArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2
               }
               {
                 field: 'Microsoft.HybridCompute/machines/extensions/type'
-                equals: 'FalconSensorWindows'
+                equals: 'TestFalconSensorWindows'
               }
               {
                 field: 'Microsoft.HybridCompute/machines/extensions/provisioningState'
@@ -1082,13 +1082,13 @@ resource windowsArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2
                 parameters: windowsTemplateParameters
                 resources: [
                   {
-                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeFalconSensor\')]'
+                    name: '[concat(parameters(\'resourceName\'), \'/CrowdStrikeTestFalconSensor\')]'
                     type: 'Microsoft.HybridCompute/machines/extensions'
                     location: '[parameters(\'location\')]'
                     apiVersion: '2024-07-10'
                     properties: {
                       publisher: 'Crowdstrike.Falcon'
-                      type: 'FalconSensorWindows'
+                      type: 'TestFalconSensorWindows'
                       typeHandlerVersion: '[parameters(\'extensionSettings\').handlerVersion]'
                       autoUpgradeMinorVersion: '[parameters(\'extensionSettings\').autoUpgradeMinorVersion]'
                       settings: {
@@ -1127,37 +1127,37 @@ resource windowsArcPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2
 
 // Create Linux Arc policy assignment at subscription level
 resource linuxArcPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
-  name: 'CS-Falcon-Linux-Arc-${take(subscription().subscriptionId, 8)}'
+  name: 'CS-Test-Linux-Arc-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     policyDefinitionId: linuxArcPolicyDefinition.id
-    displayName: 'Deploy CrowdStrike Falcon sensor on Linux Arc-connected servers (Subscription)'
-    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Linux Arc-connected servers in the subscription'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Linux Arc-connected servers (Subscription)'
+    description: 'Test policy - ensures CrowdStrike Falcon test extension is installed on all Linux Arc-connected servers in the subscription'
     parameters: commonLinuxAssignmentParameters
   }
 }
 
 // Create Windows Arc policy assignment at subscription level
 resource windowsArcPolicyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01' = if (deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
-  name: 'CS-Falcon-Windows-Arc-${take(subscription().subscriptionId, 8)}'
+  name: 'CS-Test-Windows-Arc-${take(subscription().subscriptionId, 8)}'
   location: deployment().location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     policyDefinitionId: windowsArcPolicyDefinition.id
-    displayName: 'Deploy CrowdStrike Falcon sensor on Windows Arc-connected servers (Subscription)'
-    description: 'This policy ensures CrowdStrike Falcon sensor is installed on all Windows Arc-connected servers in the subscription'
+    displayName: 'Test - Deploy CrowdStrike Falcon sensor on Windows Arc-connected servers (Subscription)'
+    description: 'Test policy - ensures CrowdStrike Falcon test extension is installed on all Windows Arc-connected servers in the subscription'
     parameters: commonWindowsAssignmentParameters
   }
 }
 
 // Create role assignments for Arc policies' managed identities
 resource linuxArcRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployToArc && (operatingSystemLower == 'linux' || operatingSystemLower == 'both')) {
-  name: guid(linuxArcPolicyAssignment.id, arcRoleDefinitionId, subscription().id, 'LinuxArc')
+  name: guid(linuxArcPolicyAssignment.id, arcRoleDefinitionId, subscription().id, 'TestLinuxArc')
   properties: {
     principalId: linuxArcPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', arcRoleDefinitionId)
@@ -1166,7 +1166,7 @@ resource linuxArcRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04
 }
 
 resource windowsArcRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createRoleAssignments && deployToArc && (operatingSystemLower == 'windows' || operatingSystemLower == 'both')) {
-  name: guid(windowsArcPolicyAssignment.id, arcRoleDefinitionId, subscription().id, 'WindowsArc')
+  name: guid(windowsArcPolicyAssignment.id, arcRoleDefinitionId, subscription().id, 'TestWindowsArc')
   properties: {
     principalId: windowsArcPolicyAssignment!.identity.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', arcRoleDefinitionId)

--- a/windows/handler/HandlerManifest.json
+++ b/windows/handler/HandlerManifest.json
@@ -6,6 +6,7 @@
     "updateCommand": "update.cmd",
     "enableCommand": "enable.cmd",
     "disableCommand": "disable.cmd",
+    "resetCommand": "reset.cmd",
     "rebootAfterInstall": false,
     "reportHeartbeat": false,
     "updateMode": "UpdateWithoutInstall",

--- a/windows/handler/helper.ps1
+++ b/windows/handler/helper.ps1
@@ -1,11 +1,28 @@
 # helper.ps1
 
 $VERSION = "0.0.0"
+$MAX_LOG_SIZE = 5MB
+
+# Check if running in an Azure Arc environment
+function Test-ArcEnvironment {
+    $arcPath = Join-Path $env:ProgramFiles "AzureConnectedMachineAgent\himds.exe"
+    return Test-Path -Path $arcPath
+}
 
 # Get the log folder path from HandlerEnvironment.json
 function Get-LogsFolder {
-    $handlerEnv = Get-Content -Raw -Path "HandlerEnvironment.json" | ConvertFrom-Json
+    $handlerEnv = Get-Content -Raw -Path (Join-Path $PSScriptRoot "HandlerEnvironment.json") | ConvertFrom-Json
     $script:LOGS_FOLDER = $handlerEnv[0].handlerEnvironment.logFolder
+}
+
+function Rotate-Log {
+    $logFile = Join-Path $LOGS_FOLDER "cshandler.log"
+    if (Test-Path $logFile) {
+        $size = (Get-Item $logFile).Length
+        if ($size -ge $MAX_LOG_SIZE) {
+            Move-Item -Path $logFile -Destination "$logFile.1" -Force
+        }
+    }
 }
 
 # Logging function
@@ -20,6 +37,8 @@ function Log {
     if (-not $script:LOGS_FOLDER) {
         Get-LogsFolder
     }
+
+    Rotate-Log
 
     $logMessage = "[$timestamp] $level $message"
     Write-Host $logMessage
@@ -52,7 +71,7 @@ function Is-SensorInstalled {
 
 # Get the configuration file path from HandlerEnvironment.json
 function Get-ConfigFile {
-    $handlerEnv = Get-Content -Raw -Path "HandlerEnvironment.json" | ConvertFrom-Json
+    $handlerEnv = Get-Content -Raw -Path (Join-Path $PSScriptRoot "HandlerEnvironment.json") | ConvertFrom-Json
     $cfgPath = $handlerEnv[0].handlerEnvironment.configFolder
     $configFilesPath = Join-Path -Path $cfgPath -ChildPath "*.settings"
 
@@ -67,8 +86,44 @@ function Get-ConfigFile {
 
 # Get the status folder path from HandlerEnvironment.json
 function Get-StatusFolder {
-    $handlerEnv = Get-Content -Raw -Path "HandlerEnvironment.json" | ConvertFrom-Json
+    $handlerEnv = Get-Content -Raw -Path (Join-Path $PSScriptRoot "HandlerEnvironment.json") | ConvertFrom-Json
     $script:STATUS_FOLDER = $handlerEnv[0].handlerEnvironment.statusFolder
+}
+
+# Extract host and port from a proxy URL, stripping scheme and credentials
+# e.g. http://user:password@proxy:8080 -> proxy:8080
+function Parse-ProxyUrl {
+    param([string]$Url)
+
+    $stripped = $Url
+    $stripped = $stripped -replace '^https?://', ''
+    $stripped = $stripped -replace '^[^@]+@', ''
+    $stripped = $stripped -replace '/.*$', ''
+
+    return $stripped
+}
+
+# Resolve proxy configuration from the Arc agent
+function Get-ArcProxyConfig {
+    if ($env:ProxySettings) {
+        $script:HTTPS_PROXY = Parse-ProxyUrl $env:ProxySettings
+        Log "INFO" "Using Arc proxy from ProxySettings environment variable: $HTTPS_PROXY"
+        return
+    }
+
+    $arcConfig = Join-Path $env:ProgramData "AzureConnectedMachineAgent\Config\localconfig.json"
+    if (Test-Path -Path $arcConfig) {
+        try {
+            $config = Get-Content -Raw -Path $arcConfig | ConvertFrom-Json
+            if ($config.'proxy.url') {
+                $script:HTTPS_PROXY = Parse-ProxyUrl $config.'proxy.url'
+                Log "INFO" "Using Arc proxy from localconfig.json: $HTTPS_PROXY"
+                return
+            }
+        } catch {
+            Log "WARN" "Failed to parse Arc proxy config: $_"
+        }
+    }
 }
 
 # Parse proxy configuration from config file
@@ -76,6 +131,14 @@ function Get-ProxyConfig {
     $script:PROXY_HOST = ""
     $script:PROXY_PORT = ""
     $script:HTTPS_PROXY = ""
+
+    # On Arc, inherit the agent's proxy settings first
+    if (Test-ArcEnvironment) {
+        Get-ArcProxyConfig
+        if ($HTTPS_PROXY) {
+            return
+        }
+    }
 
     if ($CONFIG_FILE -and (Test-Path -Path $CONFIG_FILE)) {
         try {
@@ -208,6 +271,24 @@ function Invoke-FalconInstaller {
     # Get Config file - this sets $CONFIG_FILE
     Get-ConfigFile
 
+    # Azure Arc only supports system-assigned managed identities. If a user-assigned
+    # managed identity client ID is configured, warn and clear it so the installer
+    # falls back to system-assigned identity via HIMDS challenge/response.
+    if ((Test-ArcEnvironment) -and $CONFIG_FILE -and (Test-Path -Path $CONFIG_FILE)) {
+        try {
+            $cfgJson = Get-Content -Raw -Path $CONFIG_FILE | ConvertFrom-Json
+            if ($cfgJson.runtimeSettings -and $cfgJson.runtimeSettings[0].handlerSettings) {
+                $pubSettings = $cfgJson.runtimeSettings[0].handlerSettings.publicSettings
+                $miClientId = $pubSettings.azure_managed_identity_client_id
+                if ($miClientId) {
+                    Log "WARN" "[$operationTag] Azure Arc does not support user-assigned managed identities."
+                }
+            }
+        } catch {
+            Log "WARN" "[$operationTag] Failed to parse config for managed identity check: $_"
+        }
+    }
+
     # Get proxy configuration
     Get-ProxyConfig
 
@@ -249,6 +330,30 @@ function Invoke-FalconInstaller {
     # Add uninstall flag if operation is uninstall
     if ($Operation -eq "Uninstall") {
         $installerArgs = @("--uninstall") + $installerArgs
+    }
+
+    # On Arc, append --disable-provisioning-wait if the setting doesn't exist in the config.
+    # If the customer explicitly set it (true or false), respect their choice.
+    if ((Test-ArcEnvironment) -and $Operation -ne "Uninstall") {
+        $provWaitExists = $false
+        if ($CONFIG_FILE -and (Test-Path -Path $CONFIG_FILE)) {
+            try {
+                $cfgContent = Get-Content -Raw -Path $CONFIG_FILE | ConvertFrom-Json
+                if ($cfgContent.runtimeSettings -and $cfgContent.runtimeSettings[0].handlerSettings) {
+                    $pubSettings = $cfgContent.runtimeSettings[0].handlerSettings.publicSettings
+                    if ($null -ne $pubSettings.PSObject.Properties.Item("disable_provisioning_wait")) {
+                        $provWaitExists = $true
+                    }
+                }
+            } catch {
+                Log "WARN" "[$operationTag] Failed to parse config for provisioning wait check: $_"
+            }
+        }
+
+        if (-not $provWaitExists) {
+            Log "INFO" "[$operationTag] Arc environment detected, appending --disable-provisioning-wait"
+            $installerArgs += "--disable-provisioning-wait"
+        }
     }
 
     Log "INFO" "[$operationTag] running the Falcon installer..."

--- a/windows/handler/reset.cmd
+++ b/windows/handler/reset.cmd
@@ -1,0 +1,4 @@
+@echo off
+set ES_EXT_DIR=%~dp0
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%ES_EXT_DIR%reset.ps1"
+exit /b %ERRORLEVEL%

--- a/windows/handler/reset.ps1
+++ b/windows/handler/reset.ps1
@@ -1,0 +1,21 @@
+# reset.ps1
+
+# Stop on errors
+$ErrorActionPreference = "Stop"
+
+# Get script path
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$scriptPath\helper.ps1"
+
+Log "INFO" "[RESET] Resetting extension handler state"
+
+Get-StatusFolder
+
+if (Test-Path -Path $STATUS_FOLDER) {
+    Remove-Item -Path "$STATUS_FOLDER\*.status" -Force -ErrorAction SilentlyContinue
+    Log "INFO" "[RESET] Cleared status files from $STATUS_FOLDER"
+}
+
+Log "INFO" "[RESET] Extension handler state has been reset"
+
+exit 0

--- a/windows/package/Artifacts/MainTemplate-Arc.json
+++ b/windows/package/Artifacts/MainTemplate-Arc.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "machineName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Arc-connected machine to install the extension on"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources"
+      }
+    },
+    "access-token": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Access token for accessing CrowdStrike Falcon Platform"
+      }
+    },
+    "client-id": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Client ID for accessing CrowdStrike Falcon Platform"
+      }
+    },
+    "client-secret": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Client Secret for accessing CrowdStrike Falcon Platform"
+      }
+    },
+    "cloud": {
+      "type": "string",
+      "defaultValue": "autodiscover",
+      "metadata": {
+        "description": "Falcon cloud abbreviation (e.g. us-1, us-2, eu-1, us-gov-1)"
+      }
+    },
+    "member-cid": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Member CID for MSSP (for cases when OAuth2 authenticates multiple CIDs)"
+      }
+    },
+    "sensor-update-policy": {
+      "type": "string",
+      "defaultValue": "platform_default",
+      "metadata": {
+        "description": "The sensor update policy name to use for sensor installation"
+      }
+    },
+    "disable-proxy": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Disable the sensor proxy settings"
+      }
+    },
+    "provisioning-token": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The provisioning token to use for installing the sensor. If not provided, the API will attempt to retrieve a token"
+      }
+    },
+    "proxy-host": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The proxy host for the sensor to use when communicating with CrowdStrike"
+      }
+    },
+    "proxy-port": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The proxy port for the sensor to use when communicating with CrowdStrike"
+      }
+    },
+    "tags": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "A comma separated list of tags for sensor grouping"
+      }
+    },
+    "disable-provisioning-wait": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Disable the provisioning wait timeout. Recommended for Arc deployments to avoid enable command timeouts due to Arc's CPU throttling."
+      }
+    },
+    "disable-start": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Prevent the sensor from starting after installation until a reboot occurs"
+      }
+    },
+    "pac-url": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Configure a proxy connection using the URL of a PAC file when communicating with CrowdStrike"
+      }
+    },
+    "provisioning-wait-time": {
+      "type": "string",
+      "defaultValue": "1200000",
+      "metadata": {
+        "description": "The number of milliseconds to wait for the sensor to provision"
+      }
+    },
+    "vdi": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable virtual desktop infrastructure mode"
+      }
+    },
+    "azure-vault-name": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Azure Key Vault name for retrieving CrowdStrike API credentials"
+      }
+    }
+  },
+  "variables": {
+    "extensionName": "FalconSensorWindows",
+    "extensionPublisher": "Crowdstrike.Falcon",
+    "extensionType": "FalconSensorWindows",
+    "extensionTypeHandlerVersion": "0.0"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.HybridCompute/machines/extensions",
+      "apiVersion": "2024-07-10",
+      "name": "[concat(parameters('machineName'), '/', variables('extensionName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publisher": "[variables('extensionPublisher')]",
+        "type": "[variables('extensionType')]",
+        "typeHandlerVersion": "[variables('extensionTypeHandlerVersion')]",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "azure_vault_name": "[parameters('azure-vault-name')]",
+          "cloud": "[parameters('cloud')]",
+          "member_cid": "[parameters('member-cid')]",
+          "sensor_update_policy": "[parameters('sensor-update-policy')]",
+          "disable_proxy": "[parameters('disable-proxy')]",
+          "proxy_host": "[parameters('proxy-host')]",
+          "proxy_port": "[parameters('proxy-port')]",
+          "tags": "[parameters('tags')]",
+          "disable_provisioning_wait": "[parameters('disable-provisioning-wait')]",
+          "disable_start": "[parameters('disable-start')]",
+          "pac_url": "[parameters('pac-url')]",
+          "provisioning_wait_time": "[parameters('provisioning-wait-time')]",
+          "vdi": "[parameters('vdi')]"
+        },
+        "protectedSettings": {
+          "access_token": "[parameters('access-token')]",
+          "client_id": "[parameters('client-id')]",
+          "client_secret": "[parameters('client-secret')]",
+          "provisioning_token": "[parameters('provisioning-token')]"
+        }
+      }
+    }
+  ]
+}

--- a/windows/package/Manifest.json
+++ b/windows/package/Manifest.json
@@ -20,6 +20,12 @@
       "isDefault": true
     },
     {
+      "name": "MainTemplate-Arc",
+      "type": "Template",
+      "path": "Artifacts\\MainTemplate-Arc.json",
+      "isDefault": false
+    },
+    {
       "name": "CreateUiDefinition",
       "type": "Custom",
       "path": "Artifacts\\CreateUiDefinition.json",
@@ -40,6 +46,7 @@
     }
   ],
   "categories": [
-    "compute-vmextension-windows"
+    "compute-vmextension-windows",
+    "hybridcompute-extension-windows"
   ]
 }

--- a/windows/package/UiDefinition.json
+++ b/windows/package/UiDefinition.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://gallery.azure.com/schemas/2015-02-12/uiDefinition.json#",
+  "$schema": "https://gallery.azure.com/schemas/2018-02-12/UIDefinition.json#",
   "createDefinition": {
     "createBlade": {
-      "name": "AddVmExtension",
-      "extension": "Microsoft_Azure_Compute"
+      "name": "CreateUIDefinitionBlade",
+      "extension": "Microsoft_Azure_CreateUIDef"
     }
   }
 }


### PR DESCRIPTION
Add extension support for Azure Arc-connected machines including:
- Arc environment detection and proxy inheritance from Arc agent
- Arc-specific ARM templates
- Azure Policy definitions for Arc-connected servers
- Handler reset commands for Arc migration scenarios
- Arc deployment and troubleshooting documentation
- Policy cleanup script and test infrastructure for Arc
- Fixes #22